### PR TITLE
FEATURE: add aws_dns attribute for ipv4addr

### DIFF
--- a/ifattr_test.go
+++ b/ifattr_test.go
@@ -62,6 +62,7 @@ func testSockAddrAttr(t *testing.T, sai interface{}) {
 		// IPv4
 		{"broadcast", true, false, false},
 		{"uint32", true, false, false},
+		{"aws_dns", true, false, false},
 		// IPv6
 		{"uint128", false, true, false},
 		// Unix

--- a/ipv4addr.go
+++ b/ipv4addr.go
@@ -499,6 +499,7 @@ func ipv4AddrInit() {
 		"size", // Same position as in IPv6 for output consistency
 		"broadcast",
 		"uint32",
+		"aws_dns",
 	}
 
 	ipv4AddrAttrMap = map[AttrName]func(ipv4 IPv4Addr) string{
@@ -510,6 +511,15 @@ func ipv4AddrInit() {
 		},
 		"uint32": func(ipv4 IPv4Addr) string {
 			return fmt.Sprintf("%d", uint32(ipv4.Address))
+		},
+		"aws_dns": func(ipv4 IPv4Addr) string {
+			addr := ipv4.NetworkAddress()
+			if ipv4.Maskbits() < 31 {
+				addr += 2
+			}
+			x := make(net.IP, IPv4len)
+			binary.BigEndian.PutUint32(x, uint32(addr))
+			return x.String()
 		},
 	}
 }

--- a/ipv4addr_test.go
+++ b/ipv4addr_test.go
@@ -983,9 +983,38 @@ func TestIPv4CmpRFC(t *testing.T) {
 }
 
 func TestIPv4Attrs(t *testing.T) {
-	const expectedNumAttrs = 3
+	const expectedNumAttrs = 4
 	attrs := sockaddr.IPv4Attrs()
 	if len(attrs) != expectedNumAttrs {
 		t.Fatalf("wrong number of IPv4Attrs: %d vs %d", len(attrs), expectedNumAttrs)
+	}
+}
+
+func TestIPv4Attrs_AWS_DNS(t *testing.T) {
+	for idx, test := range []struct {
+		input  string
+		output string
+	}{
+		{
+			input:  "10.200.40.1/16",
+			output: "10.200.0.2",
+		},
+		{
+			input:  "10.210.28.4/8",
+			output: "10.0.0.2",
+		},
+		{
+			input:  "192.168.78.139/24",
+			output: "192.168.78.2",
+		},
+	} {
+		ipv4, err := sockaddr.NewIPv4Addr(test.input)
+		if err != nil {
+			t.Fatalf("[%d] Unable to create an IPv4Addr from %+q: %v", idx, test.input, err)
+		}
+		result := sockaddr.IPv4AddrAttr(ipv4, "aws_dns")
+		if result != test.output {
+			t.Fatalf("[%d] Expect aws_dns %+q to be %s, got %s", idx, test.input, test.output, result)
+		}
 	}
 }

--- a/template/doc.go
+++ b/template/doc.go
@@ -228,6 +228,7 @@ IPAddr Type:
 IPv4Addr Type:
   - `broadcast`
   - `uint32`: unsigned integer representation of the value
+  - `aws_dns`: This IP address is the IP address at the base of the VPC network range "plus two." For example, if the CIDR range for your VPC is 10.0.0.0/16, the IP address of the DNS server is 10.0.0.2.
 
 IPv6Addr Type:
   - `uint128`: unsigned integer representation of the value


### PR DESCRIPTION
AmazonProvidedDNS is an Amazon DNS server, and this option enables DNS
for instances that need to communicate over the VPC's Internet gateway.
The string AmazonProvidedDNS maps to a DNS server running on a reserved
IP address at the base of the VPC IPv4 network range, plus two. For
example, the DNS Server on a 10.0.0.0/16 network is located at 10.0.0.2.

