### PR TITLE
Add math operation.

### DIFF
--- a/cmd/sockaddr/README.md
+++ b/cmd/sockaddr/README.md
@@ -149,6 +149,9 @@ EOF
 100:: fe80::1
 $ sockaddr eval 'GetPrivateInterfaces | include "flags" "forwardable|up" | include "type" "IPv4" | math "network" "+2" | attr "address"'
 172.14.6.2
+$ cat <<'EOF' | sudo tee -a /etc/profile
+export CONSUL_HTTP_ADDR="http://`sockaddr eval 'GetInterfaceIP \"eth0\"'`:8500"
+EOF
 ```
 
 ## `sockaddr rfc`

--- a/cmd/sockaddr/README.md
+++ b/cmd/sockaddr/README.md
@@ -147,6 +147,8 @@ $ cat <<'EOF' | sockaddr eval -
 {{. | include "name" "lo0" | include "type" "IPv6" | sort "address" | join "address" " "}}
 EOF
 100:: fe80::1
+$ sockaddr eval 'GetPrivateInterfaces | include "flags" "forwardable|up" | include "type" "IPv4" | math "network" "+2" | attr "address"'
+172.14.6.2
 ```
 
 ## `sockaddr rfc`

--- a/cmd/sockaddr/regression/expected/sockaddr.out
+++ b/cmd/sockaddr/regression/expected/sockaddr.out
@@ -1,4 +1,4 @@
-usage: sockaddr [--version] [--help] <command> [<args>]
+Usage: sockaddr [--version] [--help] <command> [<args>]
 
 Available commands are:
     dump            Parses input as an IP or interface name(s) and dumps various information

--- a/cmd/sockaddr/regression/expected/sockaddr_rfc-00.out
+++ b/cmd/sockaddr/regression/expected/sockaddr_rfc-00.out
@@ -10,6 +10,4 @@ Options:
   -s  Silent, only return different exit codes
 
 Subcommands:
-
     list    Lists all known RFCs
-

--- a/cmd/sockaddr/regression/expected/sockaddr_rfc-01.out
+++ b/cmd/sockaddr/regression/expected/sockaddr_rfc-01.out
@@ -8,3 +8,6 @@ Usage: sockaddr rfc [RFC Number] [IP Address]
 Options:
 
   -s  Silent, only return different exit codes
+
+Subcommands:
+    list    Lists all known RFCs

--- a/cmd/sockaddr/vendor/github.com/mitchellh/cli/README.md
+++ b/cmd/sockaddr/vendor/github.com/mitchellh/cli/README.md
@@ -5,6 +5,7 @@ cli is the library that powers the CLI for
 [Packer](https://github.com/mitchellh/packer),
 [Serf](https://github.com/hashicorp/serf),
 [Consul](https://github.com/hashicorp/consul),
+[Vault](https://github.com/hashicorp/vault),
 [Terraform](https://github.com/hashicorp/terraform), and
 [Nomad](https://github.com/hashicorp/nomad).
 

--- a/cmd/sockaddr/vendor/github.com/mitchellh/cli/cli.go
+++ b/cmd/sockaddr/vendor/github.com/mitchellh/cli/cli.go
@@ -120,7 +120,13 @@ func (c *CLI) Run() (int, error) {
 	// Just show the version and exit if instructed.
 	if c.IsVersion() && c.Version != "" {
 		c.HelpWriter.Write([]byte(c.Version + "\n"))
-		return 1, nil
+		return 0, nil
+	}
+
+	// Just print the help when only '-h' or '--help' is passed.
+	if c.IsHelp() && c.Subcommand() == "" {
+		c.HelpWriter.Write([]byte(c.HelpFunc(c.Commands) + "\n"))
+		return 0, nil
 	}
 
 	// Attempt to get the factory function for creating the command
@@ -133,13 +139,13 @@ func (c *CLI) Run() (int, error) {
 
 	command, err := raw.(CommandFactory)()
 	if err != nil {
-		return 0, err
+		return 1, err
 	}
 
 	// If we've been instructed to just print the help, then print it
 	if c.IsHelp() {
 		c.commandHelp(command)
-		return 1, nil
+		return 0, nil
 	}
 
 	// If there is an invalid flag, then error
@@ -454,7 +460,7 @@ const defaultHelpTemplate = `
 {{.Help}}{{if gt (len .Subcommands) 0}}
 
 Subcommands:
-{{ range $value := .Subcommands }}
+{{- range $value := .Subcommands }}
     {{ $value.NameAligned }}    {{ $value.Synopsis }}{{ end }}
-{{ end }}
+{{- end }}
 `

--- a/cmd/sockaddr/vendor/vendor.json
+++ b/cmd/sockaddr/vendor/vendor.json
@@ -27,10 +27,10 @@
 			"revisionTime": "2016-08-06T12:27:52Z"
 		},
 		{
-			"checksumSHA1": "W6WsJ7dtBT0coA3S5FpGR0k4IEU=",
+			"checksumSHA1": "UP+pXl+ic9y6qrpZA5MqDIAuGfw=",
 			"path": "github.com/mitchellh/cli",
-			"revision": "494eb006fe29e9dc75fea6da4df4818f7e046b73",
-			"revisionTime": "2017-02-08T07:23:55Z"
+			"revision": "ee8578a9c12a5bb9d55303b9665cc448772c81b8",
+			"revisionTime": "2017-03-28T05:23:52Z"
 		},
 		{
 			"checksumSHA1": "L3leymg2RT8hFl5uL+5KP/LpBkg=",

--- a/ifaddr_test.go
+++ b/ifaddr_test.go
@@ -98,7 +98,7 @@ func TestIfAddrAttr(t *testing.T) {
 			t.Fatalf("test %d must have a name", i)
 		}
 
-		result, err := sockaddr.IfAttr(test.attr, sockaddr.IfAddrs{test.ifAddr})
+		result, err := sockaddr.IfAttrs(test.attr, sockaddr.IfAddrs{test.ifAddr})
 		if err != nil {
 			t.Errorf("failed to get attr %q from %v", test.name, test.ifAddr)
 		}
@@ -109,7 +109,7 @@ func TestIfAddrAttr(t *testing.T) {
 	}
 
 	// Test an empty array
-	result, err := sockaddr.IfAttr("name", sockaddr.IfAddrs{})
+	result, err := sockaddr.IfAttrs("name", sockaddr.IfAddrs{})
 	if err != nil {
 		t.Error(`failed to get attr "name" from an empty array`)
 	}

--- a/ifaddr_test.go
+++ b/ifaddr_test.go
@@ -98,7 +98,7 @@ func TestIfAddrAttr(t *testing.T) {
 			t.Fatalf("test %d must have a name", i)
 		}
 
-		result, err := sockaddr.IfAttrs(test.attr, sockaddr.IfAddrs{test.ifAddr})
+		result, err := sockaddr.IfAttr(test.attr, test.ifAddr)
 		if err != nil {
 			t.Errorf("failed to get attr %q from %v", test.name, test.ifAddr)
 		}
@@ -107,14 +107,317 @@ func TestIfAddrAttr(t *testing.T) {
 			t.Errorf("unexpected result")
 		}
 	}
+}
 
-	// Test an empty array
-	result, err := sockaddr.IfAttrs("name", sockaddr.IfAddrs{})
-	if err != nil {
-		t.Error(`failed to get attr "name" from an empty array`)
+func TestIfAddrMath(t *testing.T) {
+	tests := []struct {
+		name      string
+		ifAddr    sockaddr.IfAddr
+		operation string
+		value     string
+		expected  string
+		wantFail  bool
+	}{
+		{
+			name: "ipv4 address +2",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "address",
+			value:     "+2",
+			expected:  "127.0.0.3/8",
+		},
+		{
+			name: "ipv4 address -2",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "address",
+			value:     "-2",
+			expected:  "126.255.255.255/8",
+		},
+		{
+			name: "ipv4 address + overflow 0xff00ff03",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "address",
+			value:     fmt.Sprintf("+%d", 0xff00ff03),
+			expected:  "126.0.255.4/8",
+		},
+		{
+			name: "ipv4 address - underflow 0xff00ff04",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "address",
+			value:     fmt.Sprintf("-%d", 0xff00ff04),
+			expected:  "127.255.0.253/8",
+		},
+		{
+			name: "ipv6 address +2",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::1/128"),
+			},
+			operation: "address",
+			value:     "+2",
+			expected:  "::3",
+		},
+		{
+			name: "ipv6 address -3",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::4/128"),
+			},
+			operation: "address",
+			value:     "-3",
+			expected:  "::1",
+		},
+		{
+			name: "ipv6 address + overflow",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"),
+			},
+			operation: "address",
+			value:     fmt.Sprintf("+%d", 0x03),
+			expected:  "::2",
+		},
+		{
+			name: "ipv6 address + underflow",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::1/128"),
+			},
+			operation: "address",
+			value:     fmt.Sprintf("-%d", 0x03),
+			expected:  "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe",
+		},
+		{
+			name: "ipv4 network +2",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "network",
+			value:     "+2",
+			expected:  "127.0.0.2/8",
+		},
+		{
+			name: "ipv4 network -2",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "network",
+			value:     "-2",
+			expected:  "127.255.255.254/8",
+		},
+		{
+			// Value exceeds /8
+			name: "ipv4 network + overflow 0xff00ff03",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "network",
+			value:     fmt.Sprintf("+%d", 0xff00ff03),
+			expected:  "127.0.255.3/8",
+		},
+		{
+			// Value exceeds /8
+			name: "ipv4 network - underflow+wrap 0xff00ff04",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "network",
+			value:     fmt.Sprintf("-%d", 0xff00ff04),
+			expected:  "127.255.0.252/8",
+		},
+		{
+			name: "ipv6 network +6",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("fe80::1/64"),
+			},
+			operation: "network",
+			value:     "+6",
+			expected:  "fe80::6/64",
+		},
+		{
+			name: "ipv6 network -6",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("fe80::ff/64"),
+			},
+			operation: "network",
+			value:     "-6",
+			expected:  "fe80::ffff:ffff:ffff:fffa/64",
+		},
+		{
+			// Value exceeds /104 mask
+			name: "ipv6 network + overflow 0xff00ff03",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("fe80::1/104"),
+			},
+			operation: "network",
+			value:     fmt.Sprintf("+%d", 0xff00ff03),
+			expected:  "fe80::ff03/104",
+		},
+		{
+			// Value exceeds /104
+			name: "ipv6 network - underflow+wrap 0xff00ff04",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("fe80::1/104"),
+			},
+			operation: "network",
+			value:     fmt.Sprintf("-%d", 0xff00ff04),
+			expected:  "fe80::ff:fc/104",
+		},
+		{
+			name: "ipv4 address missing sign",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "address",
+			value:     "123",
+			wantFail:  true,
+		},
+		{
+			name: "ipv4 network missing sign",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "network",
+			value:     "123",
+			wantFail:  true,
+		},
+		{
+			name: "ipv6 address missing sign",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::1/128"),
+			},
+			operation: "address",
+			value:     "123",
+			wantFail:  true,
+		},
+		{
+			name: "ipv6 network missing sign",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::1/128"),
+			},
+			operation: "network",
+			value:     "123",
+			wantFail:  true,
+		},
+		{
+			name: "ipv4 address bad value",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "address",
+			value:     "+xyz",
+			wantFail:  true,
+		},
+		{
+			name: "ipv4 network bad value",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "network",
+			value:     "-xyz",
+			wantFail:  true,
+		},
+		{
+			name: "ipv6 address bad value",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::1/128"),
+			},
+			operation: "address",
+			value:     "+xyz",
+			wantFail:  true,
+		},
+		{
+			name: "ipv6 network bad value",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::1/128"),
+			},
+			operation: "network",
+			value:     "-xyz",
+			wantFail:  true,
+		},
+		{
+			name: "ipv4 bad operation",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "gooz",
+			value:     "+xyz",
+			wantFail:  true,
+		},
+		{
+			name: "ipv6 bad operation",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::1/128"),
+			},
+			operation: "frabba",
+			value:     "+xyz",
+			wantFail:  true,
+		},
+		{
+			name: "unix unsupported operation",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustUnixSock("/tmp/bar"),
+			},
+			operation: "address",
+			value:     "+123",
+			wantFail:  true,
+		},
+		{
+			name: "unix unsupported operation",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustUnixSock("/tmp/foo"),
+			},
+			operation: "network",
+			value:     "+123",
+			wantFail:  true,
+		},
 	}
 
-	if result != "" {
-		t.Errorf("unexpected result")
+	for i, test := range tests {
+		if test.name == "" {
+			t.Fatalf("test %d must have a name", i)
+		}
+
+		results, err := sockaddr.IfAddrsMath(test.operation, test.value, sockaddr.IfAddrs{test.ifAddr})
+		if test.wantFail {
+			if err != nil {
+				continue
+			} else {
+				t.Fatalf("%s: failed to fail math operation %q with value %q on %v", test.name, test.operation, test.value, test.ifAddr)
+			}
+		} else if err != nil {
+			t.Fatalf("%s: failed to compute math operation %q with value %q on %v", test.name, test.operation, test.value, test.ifAddr)
+		}
+		if len(results) != 1 {
+			t.Fatalf("%s: bad", test.name)
+		}
+
+		result := results[0]
+
+		switch saType := result.Type(); saType {
+		case sockaddr.TypeIPv4:
+			ipv4 := sockaddr.ToIPv4Addr(result.SockAddr)
+			if ipv4 == nil {
+				t.Fatalf("bad: %T %+#v", result, result)
+			}
+
+			if got := ipv4.String(); got != test.expected {
+				t.Errorf("unexpected result %q: want %q got %q", test.name, test.expected, got)
+			}
+		case sockaddr.TypeIPv6:
+			ipv6 := sockaddr.ToIPv6Addr(result.SockAddr)
+			if ipv6 == nil {
+				t.Fatalf("bad: %T %+#v", result, result)
+			}
+
+			if got := ipv6.String(); got != test.expected {
+				t.Errorf("unexpected result %q: want %q got %q", test.name, test.expected, got)
+			}
+		default:
+			t.Fatalf("bad")
+		}
 	}
 }

--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -669,7 +669,7 @@ func IfByNetwork(selectorParam string, inputIfAddrs IfAddrs) (IfAddrs, IfAddrs, 
 	return includedIfs, excludedIfs, nil
 }
 
-// IfAddrMath will return a new IfAddr struct with a mutaterd value.
+// IfAddrMath will return a new IfAddr struct with a mutated value.
 func IfAddrMath(operation, value string, inputIfAddr IfAddr) (IfAddr, error) {
 	// Regexp used to enforce the sign being a required part of the grammar for
 	// some values.
@@ -682,7 +682,7 @@ func IfAddrMath(operation, value string, inputIfAddr IfAddr) (IfAddr, error) {
 		// underlying type.
 
 		if !signRe.MatchString(value) {
-			return IfAddr{}, fmt.Errorf("sign (+/-) is required operation %q", operation)
+			return IfAddr{}, fmt.Errorf("sign (+/-) is required for operation %q", operation)
 		}
 
 		switch sockType := inputIfAddr.SockAddr.Type(); sockType {
@@ -737,7 +737,7 @@ func IfAddrMath(operation, value string, inputIfAddr IfAddr) (IfAddr, error) {
 		// wrapping is applied.
 
 		if !signRe.MatchString(value) {
-			return IfAddr{}, fmt.Errorf("sign (+/-) is required operation %q", operation)
+			return IfAddr{}, fmt.Errorf("sign (+/-) is required for operation %q", operation)
 		}
 
 		switch sockType := inputIfAddr.SockAddr.Type(); sockType {

--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -167,9 +167,9 @@ func FilterIfByType(ifAddrs IfAddrs, type_ SockAddrType) (matchedIfs, excludedIf
 	return matchedIfs, excludedIfs
 }
 
-// IfAttr forwards the selector to IfAttr.Attr() for resolution.  If there is
+// IfAttrs forwards the selector to IfAttrs.Attr() for resolution.  If there is
 // more than one IfAddr, only the first IfAddr is used.
-func IfAttr(selectorName string, ifAddrs IfAddrs) (string, error) {
+func IfAttrs(selectorName string, ifAddrs IfAddrs) (string, error) {
 	if len(ifAddrs) == 0 {
 		return "", nil
 	}

--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -167,6 +167,14 @@ func FilterIfByType(ifAddrs IfAddrs, type_ SockAddrType) (matchedIfs, excludedIf
 	return matchedIfs, excludedIfs
 }
 
+// IfAttr forwards the selector to IfAttr.Attr() for resolution.  If there is
+// more than one IfAddr, only the first IfAddr is used.
+func IfAttr(selectorName string, ifAddr IfAddr) (string, error) {
+	attrName := AttrName(strings.ToLower(selectorName))
+	attrVal, err := ifAddr.Attr(attrName)
+	return attrVal, err
+}
+
 // IfAttrs forwards the selector to IfAttrs.Attr() for resolution.  If there is
 // more than one IfAddr, only the first IfAddr is used.
 func IfAttrs(selectorName string, ifAddrs IfAddrs) (string, error) {

--- a/ifaddrs_test.go
+++ b/ifaddrs_test.go
@@ -715,6 +715,49 @@ func TestIfAddrAttrs(t *testing.T) {
 	if len(attrs) != expectedNumAttrs {
 		t.Fatalf("wrong number of attrs")
 	}
+
+	tests := []struct {
+		name     string
+		ifAddr   sockaddr.IfAddr
+		attr     string
+		expected string
+	}{
+		{
+			name: "name",
+			ifAddr: sockaddr.IfAddr{
+				Interface: net.Interface{
+					Name: "abc0",
+				},
+			},
+			attr:     "name",
+			expected: "abc0",
+		},
+	}
+
+	for i, test := range tests {
+		if test.name == "" {
+			t.Fatalf("test %d must have a name", i)
+		}
+
+		result, err := sockaddr.IfAttrs(test.attr, sockaddr.IfAddrs{test.ifAddr})
+		if err != nil {
+			t.Errorf("failed to get attr %q from %v", test.name, test.ifAddr)
+		}
+
+		if result != test.expected {
+			t.Errorf("unexpected result")
+		}
+	}
+
+	// Test an empty array
+	result, err := sockaddr.IfAttrs("name", sockaddr.IfAddrs{})
+	if err != nil {
+		t.Error(`failed to get attr "name" from an empty array`)
+	}
+
+	if result != "" {
+		t.Errorf("unexpected result")
+	}
 }
 
 func TestGetAllInterfaces(t *testing.T) {
@@ -1877,5 +1920,4 @@ func TestSortIfBy(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/ipv4addr.go
+++ b/ipv4addr.go
@@ -58,7 +58,8 @@ func NewIPv4Addr(ipv4Str string) (IPv4Addr, error) {
 	// Strip off any bogus hex-encoded netmasks that will be mis-parsed by Go.  In
 	// particular, clients with the Barracuda VPN client will see something like:
 	// `192.168.3.51/00ffffff` as their IP address.
-	if match := trailingHexNetmaskRE.FindStringIndex(ipv4Str); match != nil {
+	trailingHexNetmaskRe := trailingHexNetmaskRE.Copy()
+	if match := trailingHexNetmaskRe.FindStringIndex(ipv4Str); match != nil {
 		ipv4Str = ipv4Str[:match[0]]
 	}
 

--- a/template/doc.go
+++ b/template/doc.go
@@ -170,6 +170,31 @@ Example:
     {{ GetPrivateInterfaces | include "flags" "forwardable|up" | offset "-2" | limit 1 }}
 
 
+`math`: Perform a "math" operation on each member of the list and return new
+values.  `math` takes two arguments, the attribute to operate on and the
+operation's value.
+
+Supported operations include:
+
+  - `address`: Adds the value, a positive or negative value expressed as a
+    decimal string, to the address.  The sign is required.  This value is
+    allowed to over or underflow networks (e.g. 127.255.255.255 `"address" "+1"`
+    will return "128.0.0.0").  Addresses will wrap at IPv4 or IPv6 boundaries.
+  - `network`: Add the value, a positive or negative value expressed as a
+    decimal string, to the network address.  The sign is required.  Positive
+    values are added to the network address.  Negative values are subtracted
+    from the network's broadcast address (e.g. 127.0.0.1 `"network" "-1"` will
+    return "127.255.255.255").  Values that overflow the network size will
+    safely wrap.
+
+Example:
+
+    {{ GetPrivateInterfaces | include "type" "IP" | math "address" "+256" | attr "address" }}
+    {{ GetPrivateInterfaces | include "type" "IP" | math "address" "-256" | attr "address" }}
+    {{ GetPrivateInterfaces | include "type" "IP" | math "network" "+2" | attr "address" }}
+    {{ GetPrivateInterfaces | include "type" "IP" | math "network" "-2" | attr "address" }}
+
+
 `attr`: Extracts a single attribute of the first member of the list and returns
 it as a string.  `attr` takes a single attribute name.  The list of available
 attributes is type-specific and shared between `join`.  See below for a list of

--- a/template/doc.go
+++ b/template/doc.go
@@ -193,6 +193,7 @@ Example:
     {{ GetPrivateInterfaces | include "type" "IP" | math "address" "-256" | attr "address" }}
     {{ GetPrivateInterfaces | include "type" "IP" | math "network" "+2" | attr "address" }}
     {{ GetPrivateInterfaces | include "type" "IP" | math "network" "-2" | attr "address" }}
+    {{ GetPrivateInterfaces | include "flags" "forwardable|up" | include "type" "IPv4" | math "network" "+2" | attr "address" }}
 
 
 `attr`: Extracts a single attribute of the first member of the list and returns

--- a/template/doc.go
+++ b/template/doc.go
@@ -180,6 +180,18 @@ Example:
     {{ GetPrivateInterfaces | include "flags" "forwardable|up" | attr "address" }}
 
 
+`Attr`: Extracts a single attribute from an `IfAttr` and in every other way
+performs the same as the `attr`.
+
+Example:
+
+    {{ with $ifAddrs := GetAllInterfaces | include "type" "IP" | sort "+type,+address" -}}
+      {{- range $ifAddrs -}}
+        {{- Attr "address" . }} -- {{ Attr "network" . }}/{{ Attr "size" . -}}
+      {{- end -}}
+    {{- end }}
+
+
 `join`: Similar to `attr`, `join` extracts all matching attributes of the list
 and returns them as a string joined by the separator, the second argument to
 `join`.  The list of available attributes is type-specific and shared between
@@ -205,7 +217,7 @@ Example:
   - `up`: Is the interface up?
 
 
-Attributes for `attr` and `join`:
+Attributes for `attr`, `Attr`, and `join`:
 
 SockAddr Type:
   - `string`

--- a/template/template.go
+++ b/template/template.go
@@ -70,6 +70,9 @@ func init() {
 		"offset": sockaddr.OffsetIfAddrs,
 		"unique": sockaddr.UniqueIfAddrsBy,
 
+		// Misc functions that operate on IfAddr input
+		"Attr": sockaddr.IfAttr,
+
 		// Return a Private RFC 6890 IP address string that is attached
 		// to the default route and a forwardable address.
 		"GetPrivateIP": sockaddr.GetPrivateIP,

--- a/template/template.go
+++ b/template/template.go
@@ -64,7 +64,7 @@ func init() {
 
 	HelperFuncs = template.FuncMap{
 		// Misc functions that operate on IfAddrs inputs
-		"attr":   sockaddr.IfAttrs,
+		"attr":   Attr,
 		"join":   sockaddr.JoinIfAddrs,
 		"limit":  sockaddr.LimitIfAddrs,
 		"offset": sockaddr.OffsetIfAddrs,
@@ -72,9 +72,6 @@ func init() {
 
 		// Misc math functions that operate on a single IfAddr input
 		"math": sockaddr.IfAddrsMath,
-
-		// Misc functions that operate on IfAddr input
-		"Attr": sockaddr.IfAttr,
 
 		// Return a Private RFC 6890 IP address string that is attached
 		// to the default route and a forwardable address.
@@ -87,6 +84,19 @@ func init() {
 		// Return the first IP address of the named interface, sorted by
 		// the largest network size.
 		"GetInterfaceIP": sockaddr.GetInterfaceIP,
+	}
+}
+
+// Attr returns the attribute from the ifAddrRaw argument.  If the argument is
+// an IfAddrs, only the first elemntt will be evaluated for resolution.
+func Attr(selectorName string, ifAddrsRaw interface{}) (string, error) {
+	switch v := ifAddrsRaw.(type) {
+	case sockaddr.IfAddr:
+		return sockaddr.IfAttr(selectorName, v)
+	case sockaddr.IfAddrs:
+		return sockaddr.IfAttrs(selectorName, v)
+	default:
+		return "", fmt.Errorf("unable to obtain attribute %s from type %T (%v)", selectorName, ifAddrsRaw, ifAddrsRaw)
 	}
 }
 

--- a/template/template.go
+++ b/template/template.go
@@ -64,7 +64,7 @@ func init() {
 
 	HelperFuncs = template.FuncMap{
 		// Misc functions that operate on IfAddrs inputs
-		"attr":   sockaddr.IfAttr,
+		"attr":   sockaddr.IfAttrs,
 		"join":   sockaddr.JoinIfAddrs,
 		"limit":  sockaddr.LimitIfAddrs,
 		"offset": sockaddr.OffsetIfAddrs,

--- a/template/template.go
+++ b/template/template.go
@@ -88,7 +88,7 @@ func init() {
 }
 
 // Attr returns the attribute from the ifAddrRaw argument.  If the argument is
-// an IfAddrs, only the first elemntt will be evaluated for resolution.
+// an IfAddrs, only the first element will be evaluated for resolution.
 func Attr(selectorName string, ifAddrsRaw interface{}) (string, error) {
 	switch v := ifAddrsRaw.(type) {
 	case sockaddr.IfAddr:

--- a/template/template.go
+++ b/template/template.go
@@ -70,6 +70,9 @@ func init() {
 		"offset": sockaddr.OffsetIfAddrs,
 		"unique": sockaddr.UniqueIfAddrsBy,
 
+		// Misc math functions that operate on a single IfAddr input
+		"math": sockaddr.IfAddrsMath,
+
 		// Misc functions that operate on IfAddr input
 		"Attr": sockaddr.IfAttr,
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -190,7 +190,7 @@ func TestSockAddr_Parse(t *testing.T) {
 			name: "math address + overflow",
 			input: `|{{- with $ifAddrs := GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | math "address" "+16777217" | sort "+type,+address" -}}
   {{- range $ifAddrs -}}
-    {{- Attr "address" . }} -- {{ Attr "network" . }}/{{ Attr "size" . }}|{{ end -}}
+    {{- attr "address" . }} -- {{ attr "network" . }}/{{ attr "size" . }}|{{ end -}}
 {{- end -}}`,
 			output: `|128.0.0.2 -- 128.0.0.0/16777216|::100:2 -- ::100:2/1|fe80::100:2 -- fe80::/18446744073709551616|`,
 		},

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -181,6 +181,61 @@ func TestSockAddr_Parse(t *testing.T) {
 {{- end -}}`,
 			output: `true`,
 		},
+		{
+			name:   "math address +",
+			input:  `{{GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | math "address" "+2" | sort "+type,+address" | join "address" " " }}`,
+			output: `127.0.0.3 ::3 fe80::3`,
+		},
+		{
+			name: "math address + overflow",
+			input: `|{{- with $ifAddrs := GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | math "address" "+16777217" | sort "+type,+address" -}}
+  {{- range $ifAddrs -}}
+    {{- Attr "address" . }} -- {{ Attr "network" . }}/{{ Attr "size" . }}|{{ end -}}
+{{- end -}}`,
+			output: `|128.0.0.2 -- 128.0.0.0/16777216|::100:2 -- ::100:2/1|fe80::100:2 -- fe80::/18446744073709551616|`,
+		},
+		{
+			name:   "math address + overflow+wrap",
+			input:  `{{GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | math "address" "+4294967294" | sort "+type,+address" | join "address" " " }}`,
+			output: `126.255.255.255 ::ffff:ffff fe80::ffff:ffff`,
+		},
+		{
+			name:   "math address -",
+			input:  `{{GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | math "address" "-256" | sort "+type,+address" | join "address" " " }}`,
+			output: `126.255.255.1 fe7f:ffff:ffff:ffff:ffff:ffff:ffff:ff01 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff01`,
+		},
+		{
+			name:   "math address - underflow",
+			input:  `{{GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | math "address" "-4278190082" | sort "+type,+address" | join "address" " " }}`,
+			output: `127.255.255.255 fe7f:ffff:ffff:ffff:ffff:ffff:ff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ff:ffff`,
+		},
+		{
+			// Note to readers: lo0's link-local address (::1) address has a mask of
+			// /128 which means its value never changes and this is expected.  lo0's
+			// site-local address has a /64 address and is expected to change.
+			name:   "math network",
+			input:  `{{GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | math "network" "+2" | sort "+type,+address" | join "address" " " }}`,
+			output: `127.0.0.2 ::1 fe80::2`,
+		},
+		{
+			// Assume an IPv4 input of 127.0.0.1.  With a value of 0xff00ff01, we wrap once on purpose.
+			name:   "math network + wrap",
+			input:  `{{GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | math "network" "+4278255368" | sort "+type,+address" | join "address" " " }}`,
+			output: `127.0.255.8 ::1 fe80::ff00:ff08`,
+		},
+		{
+			name:   "math network -",
+			input:  `{{GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | math "network" "-2" | sort "+type,+address" | join "address" " " }}`,
+			output: `127.255.255.254 ::1 fe80::ffff:ffff:ffff:fffe`,
+		},
+		{
+			// Assume an IPv4 input of 127.0.0.1.  With a value of 0xff000008 it
+			// should wrap and underflow by 8.  Assume an IPv6 input of ::1.  With a
+			// value of -0xff000008 the value underflows and wraps.
+			name:   "math network - underflow+wrap",
+			input:  `{{GetAllInterfaces | include "name" "^lo0$" | include "type" "IP" | sort "+type,+address" | math "network" "-4278190088" | join "address" " " }}`,
+			output: `127.255.255.248 ::1 fe80::ffff:ffff:ff:fff8`,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Add the `math` operation to perform calculations on IPs and networks.  …
`math` takes two arguments: an operation and a string value. The two initial
operations are `address` and `network`.

The `address` operation's value is a decimal encoded string with a mandatory
sign.  The value is added or subtracted from the IP address of the IfAddr.
Values will overflow or underflow, and if necessary, wrap at the underlying
fundamental type.

The `network` operation's value is a decimal encoded string with a mandatory
sign.  If the value is positive it is added to the network address of the
IfAddr.  If the value overflows the network size, the value is wrapped at the
network boundary (i.e. 257 will wrap in a /24 to be the same as +1).  If the
value is negative it is subtracted from the broadcast address of the IfAddr.
If the value underflows the network size, the value will wrap.

The `network` operation is intended to address the concern raised in #7 but
in a more generic way and with IPv6 support, thereby superseding #7.  For instance, to get the DNS resolver, one would simply use:

```
{{GetPrivateIP | math "network" "+2"}}
```

Thank you @taylorchu for the feature request.  Can you let me know if this PR meets your needs?  I know it scratches my back in terms of something that I've needed for a while now.