### PR TITLE
Fix convenience functions for dual-homed hosts

### DIFF
--- a/cmd/sockaddr/README.md
+++ b/cmd/sockaddr/README.md
@@ -119,7 +119,7 @@ Options:
 Here are a few impractical examples to get you started:
 
 ```text
-$ sockaddr eval 'GetDefaultInterfaces | sort "type,size" | include "RFC" "6890" | attr "address"'
+$ sockaddr eval 'GetAllInterfaces | include "flags" "forwardable" | include "up" | sort "default,type,size" | include "RFC" "6890" | attr "address"'
 172.14.6.167
 $ sockaddr eval 'GetDefaultInterfaces | sort "type,size" | include "RFC" "6890" | limit 1 | join "address" " "'
 172.14.6.167
@@ -133,7 +133,7 @@ $ sockaddr eval 'GetAllInterfaces | include "network" "172.14.6.0/24" | attr "ad
 172.14.6.167
 $ sockaddr eval 'GetPrivateInterfaces | join "type" " "'
 IPv4 IPv6
-$ sockaddr eval 'GetPublicInterfaces | include "flags" "up|forwardable" | join "address" " "'
+$ sockaddr eval 'GetAllInterfaces | include "flags" "forwardable" | join "address" " "'
 203.0.113.4 2001:0DB8::1
 $ sockaddr eval 'GetAllInterfaces | include "name" "lo0" | include "type" "IPv6" | sort "address" | join "address" " "'
 100:: fe80::1

--- a/cmd/sockaddr/regression/run_all.sh
+++ b/cmd/sockaddr/regression/run_all.sh
@@ -1,11 +1,13 @@
 #!/bin/sh --
 
+FIND=`/usr/bin/which 2> /dev/null gfind find | /usr/bin/grep -v ^no | /usr/bin/head -n 1`
+XARGS=`/usr/bin/which 2> /dev/null gxargs xargs | /usr/bin/grep -v ^no | /usr/bin/head -n 1`
 set -e
 set -u
 
 num_cpus=$(getconf NPROCESSORS_ONLN)
 set +e
-find . -name 'test_*.sh' -depth 1 | xargs -n1 -P${num_cpus} ./run_one.sh
+${FIND} . -maxdepth 1 -name 'test_*.sh' -print0 | ${XARGS} -0 -n1 -P${num_cpus} ./run_one.sh
 set -e
 
 # rune_one.sh generates the .diff files

--- a/cmd/sockaddr/version.go
+++ b/cmd/sockaddr/version.go
@@ -12,7 +12,7 @@ var (
 )
 
 // The main version number that is being run at the moment.
-const Version = "0.1.0"
+const Version = "0.2.0"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release

--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -243,10 +243,10 @@ func GetDefaultInterfaces() (IfAddrs, error) {
 // the `eval` equivalent of:
 //
 // ```
-// $ sockaddr eval -r '{{GetDefaultInterfaces | include "type" "ip" | include "flags" "forwardable|up" | sort "type,size" | include "RFC" "6890" }}'
+// $ sockaddr eval -r '{{GetAllInterfaces | include "type" "ip" | include "flags" "forwardable" | include "flags" "up" | sort "type,size" | include "RFC" "6890" }}'
 /// ```
 func GetPrivateInterfaces() (IfAddrs, error) {
-	privateIfs, err := GetDefaultInterfaces()
+	privateIfs, err := GetAllInterfaces()
 	if err != nil {
 		return IfAddrs{}, err
 	}
@@ -259,10 +259,16 @@ func GetPrivateInterfaces() (IfAddrs, error) {
 		return IfAddrs{}, nil
 	}
 
-	privateIfs, _, err = IfByFlag("forwardable|up", privateIfs)
+	privateIfs, _, err = IfByFlag("forwardable", privateIfs)
 	if err != nil {
 		return IfAddrs{}, err
 	}
+
+	privateIfs, _, err = IfByFlag("up", privateIfs)
+	if err != nil {
+		return IfAddrs{}, err
+	}
+
 	if len(privateIfs) == 0 {
 		return IfAddrs{}, nil
 	}
@@ -285,10 +291,10 @@ func GetPrivateInterfaces() (IfAddrs, error) {
 // function is the `eval` equivalent of:
 //
 // ```
-// $ sockaddr eval -r '{{GetDefaultInterfaces | include "type" "ip" | include "flags" "forwardable|up" | sort "type,size" | exclude "RFC" "6890" }}'
+// $ sockaddr eval -r '{{GetAllInterfaces | include "type" "ip" | include "flags" "forwardable" | include "flags" "up" | sort "type,size" | exclude "RFC" "6890" }}'
 /// ```
 func GetPublicInterfaces() (IfAddrs, error) {
-	publicIfs, err := GetDefaultInterfaces()
+	publicIfs, err := GetAllInterfaces()
 	if err != nil {
 		return IfAddrs{}, err
 	}
@@ -301,10 +307,16 @@ func GetPublicInterfaces() (IfAddrs, error) {
 		return IfAddrs{}, nil
 	}
 
-	publicIfs, _, err = IfByFlag("forwardable|up", publicIfs)
+	publicIfs, _, err = IfByFlag("forwardable", publicIfs)
 	if err != nil {
 		return IfAddrs{}, err
 	}
+
+	publicIfs, _, err = IfByFlag("up", publicIfs)
+	if err != nil {
+		return IfAddrs{}, err
+	}
+
 	if len(publicIfs) == 0 {
 		return IfAddrs{}, nil
 	}

--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -91,6 +91,40 @@ func AscIfAddress(p1Ptr, p2Ptr *IfAddr) int {
 	return AscAddress(&p1Ptr.SockAddr, &p2Ptr.SockAddr)
 }
 
+// AscIfDefault is a sorting function to sort IfAddrs by whether or not they
+// have a default route or not.  Non-equal types are deferred in the sort.
+//
+// FIXME: This is a particularly expensive sorting operation because of the
+// non-memoized calls to NewRouteInfo().  In an ideal world the routeInfo data
+// once at the start of the sort and pass it along as a context or by wrapping
+// the IfAddr type with this information (this would also solve the inability to
+// return errors and the possibility of failing silently).  Fortunately,
+// N*log(N) where N = 3 is only ~6.2 invocations.  Not ideal, but not worth
+// optimizing today.  The common case is this gets called once or twice.
+// Patches welcome.
+func AscIfDefault(p1Ptr, p2Ptr *IfAddr) int {
+	ri, err := NewRouteInfo()
+	if err != nil {
+		return sortDeferDecision
+	}
+
+	defaultIfName, err := ri.GetDefaultInterfaceName()
+	if err != nil {
+		return sortDeferDecision
+	}
+
+	switch {
+	case p1Ptr.Interface.Name == defaultIfName && p2Ptr.Interface.Name == defaultIfName:
+		return sortDeferDecision
+	case p1Ptr.Interface.Name == defaultIfName:
+		return sortReceiverBeforeArg
+	case p2Ptr.Interface.Name == defaultIfName:
+		return sortArgBeforeReceiver
+	default:
+		return sortDeferDecision
+	}
+}
+
 // AscIfName is a sorting function to sort IfAddrs by their interface names.
 func AscIfName(p1Ptr, p2Ptr *IfAddr) int {
 	return strings.Compare(p1Ptr.Name, p2Ptr.Name)
@@ -125,6 +159,11 @@ func AscIfType(p1Ptr, p2Ptr *IfAddr) int {
 // DescIfAddress is identical to AscIfAddress but reverse ordered.
 func DescIfAddress(p1Ptr, p2Ptr *IfAddr) int {
 	return -1 * AscAddress(&p1Ptr.SockAddr, &p2Ptr.SockAddr)
+}
+
+// DescIfDefault is identical to AscIfDefault but reverse ordered.
+func DescIfDefault(p1Ptr, p2Ptr *IfAddr) int {
+	return -1 * AscIfDefault(p1Ptr, p2Ptr)
 }
 
 // DescIfName is identical to AscIfName but reverse ordered.
@@ -243,7 +282,7 @@ func GetDefaultInterfaces() (IfAddrs, error) {
 // the `eval` equivalent of:
 //
 // ```
-// $ sockaddr eval -r '{{GetAllInterfaces | include "type" "ip" | include "flags" "forwardable" | include "flags" "up" | sort "type,size" | include "RFC" "6890" }}'
+// $ sockaddr eval -r '{{GetAllInterfaces | include "type" "ip" | include "flags" "forwardable" | include "flags" "up" | sort "default,type,size" | include "RFC" "6890" }}'
 /// ```
 func GetPrivateInterfaces() (IfAddrs, error) {
 	privateIfs, err := GetAllInterfaces()
@@ -273,7 +312,7 @@ func GetPrivateInterfaces() (IfAddrs, error) {
 		return IfAddrs{}, nil
 	}
 
-	OrderedIfAddrBy(AscIfType, AscIfNetworkSize).Sort(privateIfs)
+	OrderedIfAddrBy(AscIfDefault, AscIfType, AscIfNetworkSize).Sort(privateIfs)
 
 	privateIfs, _, err = IfByRFC("6890", privateIfs)
 	if err != nil {
@@ -291,7 +330,7 @@ func GetPrivateInterfaces() (IfAddrs, error) {
 // function is the `eval` equivalent of:
 //
 // ```
-// $ sockaddr eval -r '{{GetAllInterfaces | include "type" "ip" | include "flags" "forwardable" | include "flags" "up" | sort "type,size" | exclude "RFC" "6890" }}'
+// $ sockaddr eval -r '{{GetAllInterfaces | include "type" "ip" | include "flags" "forwardable" | include "flags" "up" | sort "default,type,size" | exclude "RFC" "6890" }}'
 /// ```
 func GetPublicInterfaces() (IfAddrs, error) {
 	publicIfs, err := GetAllInterfaces()
@@ -321,7 +360,7 @@ func GetPublicInterfaces() (IfAddrs, error) {
 		return IfAddrs{}, nil
 	}
 
-	OrderedIfAddrBy(AscIfType, AscIfNetworkSize).Sort(publicIfs)
+	OrderedIfAddrBy(AscIfDefault, AscIfType, AscIfNetworkSize).Sort(publicIfs)
 
 	_, publicIfs, err = IfByRFC("6890", publicIfs)
 	if err != nil {
@@ -748,6 +787,10 @@ func SortIfBy(selectorParam string, inputIfAddrs IfAddrs) (IfAddrs, error) {
 			sortFuncs[i] = AscIfAddress
 		case "-address":
 			sortFuncs[i] = DescIfAddress
+		case "+default", "default":
+			sortFuncs[i] = AscIfDefault
+		case "-default":
+			sortFuncs[i] = DescIfDefault
 		case "+name", "name":
 			// The "name" selector returns an array of IfAddrs
 			// ordered by the interface name.

--- a/ifaddrs_test.go
+++ b/ifaddrs_test.go
@@ -9,6 +9,13 @@ import (
 	sockaddr "github.com/hashicorp/go-sockaddr"
 )
 
+const (
+	// NOTE(seanc@): Assume "en0" is the interface with a default route attached
+	// to it.  When this is not the case, change this one constant and tests
+	// should pass (i.e. "net0").
+	ifNameWithDefault = "en0"
+)
+
 // NOTE: A number of these code paths are exercised in template/ and
 // cmd/sockaddr/.
 //
@@ -1666,6 +1673,82 @@ func TestSortIfBy(t *testing.T) {
 			out: sockaddr.IfAddrs{
 				sockaddr.IfAddr{SockAddr: sockaddr.MustIPv4Addr("1.2.3.4")},
 				sockaddr.IfAddr{SockAddr: sockaddr.MustIPv4Addr("1.2.3.3")},
+			},
+		},
+		{
+			// NOTE(seanc@): This test requires macOS, or at least a computer where
+			// en0 has the default route.
+			name:    "sort default",
+			sortStr: "default",
+			in: sockaddr.IfAddrs{
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.4"),
+					Interface: net.Interface{Name: ifNameWithDefault},
+				},
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.3"),
+					Interface: net.Interface{Name: "other0"},
+				},
+			},
+			out: sockaddr.IfAddrs{
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.4"),
+					Interface: net.Interface{Name: ifNameWithDefault},
+				},
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.3"),
+					Interface: net.Interface{Name: "other0"},
+				},
+			},
+		},
+		{
+			// NOTE(seanc@): This test requires macOS, or at least a computer where
+			// en0 has the default route.
+			name:    "sort +default",
+			sortStr: "+default",
+			in: sockaddr.IfAddrs{
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.4"),
+					Interface: net.Interface{Name: "other0"},
+				},
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.3"),
+					Interface: net.Interface{Name: ifNameWithDefault},
+				},
+			},
+			out: sockaddr.IfAddrs{
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.3"),
+					Interface: net.Interface{Name: ifNameWithDefault},
+				},
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.4"),
+					Interface: net.Interface{Name: "other0"},
+				},
+			},
+		},
+		{
+			name:    "sort -default",
+			sortStr: "-default",
+			in: sockaddr.IfAddrs{
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.3"),
+					Interface: net.Interface{Name: ifNameWithDefault},
+				},
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.4"),
+					Interface: net.Interface{Name: "other0"},
+				},
+			},
+			out: sockaddr.IfAddrs{
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.4"),
+					Interface: net.Interface{Name: "other0"},
+				},
+				sockaddr.IfAddr{
+					SockAddr:  sockaddr.MustIPv4Addr("1.2.3.3"),
+					Interface: net.Interface{Name: ifNameWithDefault},
+				},
 			},
 		},
 		{

--- a/template/doc.go
+++ b/template/doc.go
@@ -100,6 +100,8 @@ argument, a list of ways to sort its IfAddrs argument.  The list of sort
 criteria is comma separated (`,`):
   - `address`, `+address`: Ascending sort of IfAddrs by Address
   - `-address`: Descending sort of IfAddrs by Address
+  - `default`, `+default`: Ascending sort of IfAddrs, IfAddr with a default route first
+  - `-default`: Descending sort of IfAddrs, IfAttr with default route last
   - `name`, `+name`: Ascending sort of IfAddrs by lexical ordering of interface name
   - `-name`: Descending sort of IfAddrs by lexical ordering of interface name
   - `port`, `+port`: Ascending sort of IfAddrs by port number

--- a/template/doc.go
+++ b/template/doc.go
@@ -53,23 +53,22 @@ Example:
     {{ GetDefaultInterfaces }}
 
 `GetPrivateInterfaces` - Returns one IfAddr for every forwardable IP address
-that is included in RFC 6890, is attached to the interface with the default
-route, and whose interface is marked as up.  NOTE: RFC 6890 is a more exhaustive
-version of RFC1918 because it spans IPv4 and IPv6, however it does permit the
+that is included in RFC 6890 and whose interface is marked as up.  NOTE: RFC 6890 is a more exhaustive
+version of RFC1918 because it spans IPv4 and IPv6, however, RFC6890 does permit the
 inclusion of likely undesired addresses such as multicast, therefore our version
 of "private" also filters out non-forwardable addresses.
 
 Example:
 
-    {{ GetPrivateInterfaces | include "flags" "up" }}
+    {{ GetPrivateInterfaces | sort "default" | join "address" " " }}
 
 
-`GetPublicInterfaces` - Returns a list of IfAddr that do not match RFC 6890, is
-attached to the default route, and whose interface is marked as up.
+`GetPublicInterfaces` - Returns a list of IfAddr structs whos IPs are
+forwardable, do not match RFC 6890, and whose interface is marked up.
 
 Example:
 
-    {{ GetPublicInterfaces | include "flags" "up" }}
+    {{ GetPublicInterfaces | sort "default" | join "name" " " }}
 
 
 `GetPrivateIP` - Helper function that returns a string of the first IP address
@@ -92,7 +91,7 @@ the named interface.
 
 Example:
 
-    {{ GetInterfaceIP }}
+    {{ GetInterfaceIP "eth1" }}
 
 
 `sort` - Sorts the IfAddrs result based on its arguments.  `sort` takes one
@@ -118,7 +117,7 @@ criteria is comma separated (`,`):
 
 Example:
 
-    {{ GetPrivateInterfaces | sort "type,size,address" }}
+    {{ GetPrivateInterfaces | sort "default,-type,size,+address" }}
 
 
 `exclude` and `include`: Filters IfAddrs based on the selector criteria and its
@@ -144,7 +143,7 @@ available filtering criteria is:
 
 Example:
 
-    {{ GetPrivateInterfaces | exclude "type" "IPv6" | include "flag" "up|forwardable" }}
+    {{ GetPrivateInterfaces | exclude "type" "IPv6" }}
 
 
 `unique`: Removes duplicate entries from the IfAddrs list, assuming the list has
@@ -154,14 +153,14 @@ already been sorted.  `unique` only takes one argument:
 
 Example:
 
-    {{ GetPrivateInterfaces | sort "type,address" | unique "name" }}
+    {{ GetAllInterfaces | sort "default,-type,address" | unique "name" }}
 
 
 `limit`: Reduces the size of the list to the specified value.
 
 Example:
 
-    {{ GetPrivateInterfaces | include "flags" "forwardable|up" | limit 1 }}
+    {{ GetPrivateInterfaces | limit 1 }}
 
 
 `offset`: Seeks into the list by the specified value.  A negative value can be
@@ -169,7 +168,7 @@ used to seek from the end of the list.
 
 Example:
 
-    {{ GetPrivateInterfaces | include "flags" "forwardable|up" | offset "-2" | limit 1 }}
+    {{ GetPrivateInterfaces | offset "-2" | limit 1 }}
 
 
 `attr`: Extracts a single attribute of the first member of the list and returns
@@ -179,7 +178,7 @@ supported attributes.
 
 Example:
 
-    {{ GetPrivateInterfaces | include "flags" "forwardable|up" | attr "address" }}
+    {{ GetAllInterfaces | exclude "flags" "up" | attr "address" }}
 
 
 `join`: Similar to `attr`, `join` extracts all matching attributes of the list
@@ -189,7 +188,7 @@ and returns them as a string joined by the separator, the second argument to
 
 Example:
 
-    {{ GetPrivateInterfaces | include "flags" "forwardable|up" | join "address" " " }}
+    {{ GetAllInterfaces | include "flags" "forwardable" | join "address" " " }}
 
 
 `exclude` and `include` flags:


### PR DESCRIPTION
Previously, on dual-homed hosts the `GetPrivateIP`, `GetPublicIP`, `GetPrivateInterfaces`, and `GetPublicInterfaces` methods could return incorrect values.

Suppose the hypothetical host:

- `net0` has a public IP and has adjacency to the default route
- `net1` has a private IP

Under this scenario, `GetPublicIP` and `GetPublicInterfaces` would succeed, but `GetPrivateIP` and `GetPrivateInterfaces` would not because `GetPrivateInterfaces` was incorrectly using `GetDefaultInterfaces` at its initial seed of `IfAddrs`.  Instead, change the behavior to use `GetAllInterfaces` and then sort based on whether or not the interface has a default route, meaning we prefer `IfAddr` entries that have a default route, but it isn't required.  Provide the same logic for `GetPublicInterface`.

Fix a bug where the flags selector was `OR`ing two conditions: `flags "forwardable|up"` was incorrect, it should have been `flags "forwardable" | flags "up"`.  Without this change it was possible that `GetPrivateIP` could return the loopback address because it is `up` even if it is not `forwardable`.