### PR TITLE
Lookup IP on $PATH to support unusual locations

### DIFF
--- a/route_info_linux.go
+++ b/route_info_linux.go
@@ -5,10 +5,6 @@ import (
 	"os/exec"
 )
 
-var cmds map[string][]string = map[string][]string{
-	"ip": {"/sbin/ip", "route"},
-}
-
 type routeInfo struct {
 	cmds map[string][]string
 }
@@ -16,15 +12,22 @@ type routeInfo struct {
 // NewRouteInfo returns a Linux-specific implementation of the RouteInfo
 // interface.
 func NewRouteInfo() (routeInfo, error) {
+	// CoreOS Container Linux moved ip to /usr/bin/ip, so look it up on
+	// $PATH and fallback to /sbin/ip on error.
+	path, _ := exec.LookPath("ip")
+	if path == "" {
+		path = "/sbin/ip"
+	}
+
 	return routeInfo{
-		cmds: cmds,
+		cmds: map[string][]string{"ip": {path, "route"}},
 	}, nil
 }
 
 // GetDefaultInterfaceName returns the interface name attached to the default
 // route on the default interface.
 func (ri routeInfo) GetDefaultInterfaceName() (string, error) {
-	out, err := exec.Command(cmds["ip"][0], cmds["ip"][1:]...).Output()
+	out, err := exec.Command(ri.cmds["ip"][0], ri.cmds["ip"][1:]...).Output()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #12

Manually tested on Ubuntu 17.04 (`/sbin/ip`) and CoreOS 1409.2.0
(`/usr/bin/ip`).