### PR TITLE
Add mask operation on IPv4 and IPv6 interfaces

### DIFF
--- a/ifaddr_test.go
+++ b/ifaddr_test.go
@@ -411,6 +411,102 @@ func TestIfAddrMath(t *testing.T) {
 			wantFail:  true,
 		},
 		{
+			// Subnet of input IPv4Addr is equal to mask operation parameter subnet
+			name: "ipv4 mask equal",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("10.20.30.40/8"),
+			},
+			operation: "mask",
+			value:     "8",
+			expected:  "10.0.0.0/8",
+		},
+		{
+			// Subnet of input IPv4Addr is smaller than mask operation parameter subnet
+			name: "ipv4 mask larger parameter subnet",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("192.168.10.20/24"),
+			},
+			operation: "mask",
+			value:     "16",
+			expected:  "192.168.0.0/16",
+		},
+		{
+			// Subnet of input IPv4Addr is larger than mask operation parameter subnet
+			name: "ipv4 mask larger parameter subnet",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("192.168.10.20/8"),
+			},
+			operation: "mask",
+			value:     "16",
+			expected:  "192.168.0.0/8",
+		},
+		{
+			name: "ipv4 mask bad value upper bound",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "mask",
+			value:     "33",
+			wantFail:  true,
+		},
+		{
+			name: "ipv4 mask bad value lower bound",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("127.0.0.1/8"),
+			},
+			operation: "mask",
+			value:     "-1",
+			wantFail:  true,
+		},
+		{
+			// Subnet of input IPv6Addr is equal to mask operation parameter subnet
+			name: "ipv6 mask equal",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("2001:0db8:85a3::8a2e:0370:7334/64"),
+			},
+			operation: "mask",
+			value:     "64",
+			expected:  "2001:db8:85a3::/64",
+		},
+		{
+			// Subnet of input IPv6Addr is smaller than mask operation parameter subnet
+			name: "ipv6 mask larger parameter subnet",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("2001:0db8:85a3::8a2e:0370:7334/64"),
+			},
+			operation: "mask",
+			value:     "32",
+			expected:  "2001:db8::/32",
+		},
+		{
+			// Subnet of input IPv4Addr is larger than mask operation parameter subnet
+			name: "ipv6 mask larger parameter subnet",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("2001:0db8:85a3::8a2e:0370:7334/64"),
+			},
+			operation: "mask",
+			value:     "96",
+			expected:  "2001:db8:85a3::8a2e:0:0/64",
+		},
+		{
+			name: "ipv6 mask bad value upper bound",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::1/128"),
+			},
+			operation: "mask",
+			value:     "129",
+			wantFail:  true,
+		},
+		{
+			name: "ipv6 mask bad value lower bound",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv6Addr("::1/128"),
+			},
+			operation: "mask",
+			value:     "-1",
+			wantFail:  true,
+		},
+		{
 			name: "unix unsupported operation",
 			ifAddr: sockaddr.IfAddr{
 				SockAddr: sockaddr.MustUnixSock("/tmp/bar"),
@@ -426,6 +522,15 @@ func TestIfAddrMath(t *testing.T) {
 			},
 			operation: "network",
 			value:     "+123",
+			wantFail:  true,
+		},
+		{
+			name: "unix unsupported operation",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustUnixSock("/tmp/foo"),
+			},
+			operation: "mask",
+			value:     "8",
 			wantFail:  true,
 		},
 	}

--- a/ifaddr_test.go
+++ b/ifaddr_test.go
@@ -411,8 +411,7 @@ func TestIfAddrMath(t *testing.T) {
 			wantFail:  true,
 		},
 		{
-			// Subnet of input IPv4Addr is equal to mask operation parameter subnet
-			name: "ipv4 mask equal",
+			name: "ipv4 mask operand equals input ipv4 subnet mask",
 			ifAddr: sockaddr.IfAddr{
 				SockAddr: sockaddr.MustIPv4Addr("10.20.30.40/8"),
 			},
@@ -421,8 +420,7 @@ func TestIfAddrMath(t *testing.T) {
 			expected:  "10.0.0.0/8",
 		},
 		{
-			// Subnet of input IPv4Addr is smaller than mask operation parameter subnet
-			name: "ipv4 mask larger parameter subnet",
+			name: "ipv4 mask operand larger than input ipv4 subnet mask",
 			ifAddr: sockaddr.IfAddr{
 				SockAddr: sockaddr.MustIPv4Addr("192.168.10.20/24"),
 			},
@@ -431,14 +429,31 @@ func TestIfAddrMath(t *testing.T) {
 			expected:  "192.168.0.0/16",
 		},
 		{
-			// Subnet of input IPv4Addr is larger than mask operation parameter subnet
-			name: "ipv4 mask larger parameter subnet",
+			name: "ipv4 host upper bound mask operand larger than input ipv4 subnet mask",
 			ifAddr: sockaddr.IfAddr{
-				SockAddr: sockaddr.MustIPv4Addr("192.168.10.20/8"),
+				SockAddr: sockaddr.MustIPv4Addr("192.168.255.255/24"),
 			},
 			operation: "mask",
 			value:     "16",
-			expected:  "192.168.0.0/8",
+			expected:  "192.168.0.0/16",
+		},
+		{
+			name: "ipv4 mask operand smaller than ipv4 subnet mask",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("10.20.30.40/8"),
+			},
+			operation: "mask",
+			value:     "16",
+			expected:  "10.20.0.0/8",
+		},
+		{
+			name: "ipv4 host upper bound mask operand smaller than input ipv4 subnet mask",
+			ifAddr: sockaddr.IfAddr{
+				SockAddr: sockaddr.MustIPv4Addr("10.20.255.255/8"),
+			},
+			operation: "mask",
+			value:     "16",
+			expected:  "10.20.0.0/8",
 		},
 		{
 			name: "ipv4 mask bad value upper bound",
@@ -459,8 +474,7 @@ func TestIfAddrMath(t *testing.T) {
 			wantFail:  true,
 		},
 		{
-			// Subnet of input IPv6Addr is equal to mask operation parameter subnet
-			name: "ipv6 mask equal",
+			name: "ipv6 mask operand equals input ipv6 subnet mask",
 			ifAddr: sockaddr.IfAddr{
 				SockAddr: sockaddr.MustIPv6Addr("2001:0db8:85a3::8a2e:0370:7334/64"),
 			},
@@ -469,8 +483,7 @@ func TestIfAddrMath(t *testing.T) {
 			expected:  "2001:db8:85a3::/64",
 		},
 		{
-			// Subnet of input IPv6Addr is smaller than mask operation parameter subnet
-			name: "ipv6 mask larger parameter subnet",
+			name: "ipv6 mask operand larger than input ipv6 subnet mask",
 			ifAddr: sockaddr.IfAddr{
 				SockAddr: sockaddr.MustIPv6Addr("2001:0db8:85a3::8a2e:0370:7334/64"),
 			},
@@ -479,8 +492,7 @@ func TestIfAddrMath(t *testing.T) {
 			expected:  "2001:db8::/32",
 		},
 		{
-			// Subnet of input IPv4Addr is larger than mask operation parameter subnet
-			name: "ipv6 mask larger parameter subnet",
+			name: "ipv6 mask operand smaller than input ipv6 subnet mask",
 			ifAddr: sockaddr.IfAddr{
 				SockAddr: sockaddr.MustIPv6Addr("2001:0db8:85a3::8a2e:0370:7334/64"),
 			},

--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -879,7 +879,7 @@ func IfAddrMath(operation, value string, inputIfAddr IfAddr) (IfAddr, error) {
 				return IfAddr{}, fmt.Errorf("unable to convert %q to int for operation %q: %v", value, operation, err)
 			}
 
-			if i < 0 || i > 32 {
+			if i > 32 {
 				return IfAddr{}, fmt.Errorf("parameter for operation %q on ipv4 addresses must be between 0 and 32", operation)
 			}
 
@@ -905,12 +905,12 @@ func IfAddrMath(operation, value string, inputIfAddr IfAddr) (IfAddr, error) {
 				Interface: inputIfAddr.Interface,
 			}, nil
 		case TypeIPv6:
-			i, err := strconv.ParseInt(value, 10, 32)
+			i, err := strconv.ParseUint(value, 10, 32)
 			if err != nil {
 				return IfAddr{}, fmt.Errorf("unable to convert %q to int for operation %q: %v", value, operation, err)
 			}
 
-			if i < 0 || i > 128 {
+			if i > 128 {
 				return IfAddr{}, fmt.Errorf("parameter for operation %q on ipv6 addresses must be between 0 and 64", operation)
 			}
 

--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -1,6 +1,7 @@
 package sockaddr
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -860,6 +861,80 @@ func IfAddrMath(operation, value string, inputIfAddr IfAddr) (IfAddr, error) {
 				SockAddr: IPv6Addr{
 					Address: IPv6Address(ipv6BigInt),
 					Mask:    ipv6.Mask,
+				},
+				Interface: inputIfAddr.Interface,
+			}, nil
+		default:
+			return IfAddr{}, fmt.Errorf("unsupported type for operation %q: %T", operation, sockType)
+		}
+	case "mask":
+		// "mask" operates on the IP address and returns the IP address on
+		// which the given integer mask has been applied. If the applied mask
+		// corresponds to a larger network than the mask of the IP address,
+		// the latter will be replaced by the former.
+		switch sockType := inputIfAddr.SockAddr.Type(); sockType {
+		case TypeIPv4:
+			i, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return IfAddr{}, fmt.Errorf("unable to convert %q to int for operation %q: %v", value, operation, err)
+			}
+
+			if i < 0 || i > 32 {
+				return IfAddr{}, fmt.Errorf("parameter for operation %q on ipv4 addresses must be between 0 and 32", operation)
+			}
+
+			ipv4 := *ToIPv4Addr(inputIfAddr.SockAddr)
+
+			ipv4Mask := net.CIDRMask(int(i), 32)
+			ipv4MaskUint32 := binary.BigEndian.Uint32(ipv4Mask)
+
+			maskedIpv4 := ipv4.NetIP().Mask(ipv4Mask)
+			maskedIpv4Uint32 := binary.BigEndian.Uint32(maskedIpv4)
+
+			maskedIpv4MaskUint32 := uint32(ipv4.Mask)
+
+			if ipv4MaskUint32 < maskedIpv4MaskUint32 {
+				maskedIpv4MaskUint32 = ipv4MaskUint32
+			}
+
+			return IfAddr{
+				SockAddr: IPv4Addr{
+					Address: IPv4Address(maskedIpv4Uint32),
+					Mask:    IPv4Mask(maskedIpv4MaskUint32),
+				},
+				Interface: inputIfAddr.Interface,
+			}, nil
+		case TypeIPv6:
+			i, err := strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return IfAddr{}, fmt.Errorf("unable to convert %q to int for operation %q: %v", value, operation, err)
+			}
+
+			if i < 0 || i > 128 {
+				return IfAddr{}, fmt.Errorf("parameter for operation %q on ipv6 addresses must be between 0 and 64", operation)
+			}
+
+			ipv6 := *ToIPv6Addr(inputIfAddr.SockAddr)
+
+			ipv6Mask := net.CIDRMask(int(i), 128)
+			ipv6MaskBigInt := new(big.Int)
+			ipv6MaskBigInt.SetBytes(ipv6Mask)
+
+			maskedIpv6 := ipv6.NetIP().Mask(ipv6Mask)
+			maskedIpv6BigInt := new(big.Int)
+			maskedIpv6BigInt.SetBytes(maskedIpv6)
+
+			maskedIpv6MaskBigInt := new(big.Int)
+			maskedIpv6MaskBigInt.Set(ipv6.Mask)
+
+			if ipv6MaskBigInt.Cmp(maskedIpv6MaskBigInt) == -1 {
+				maskedIpv6MaskBigInt = ipv6MaskBigInt
+			}
+
+			return IfAddr{
+				SockAddr: IPv6Addr{
+					Address: IPv6Address(maskedIpv6BigInt),
+					Mask:    IPv6Mask(maskedIpv6MaskBigInt),
 				},
 				Interface: inputIfAddr.Interface,
 			}, nil

--- a/template/doc.go
+++ b/template/doc.go
@@ -212,6 +212,13 @@ Supported operations include:
     from the network's broadcast address (e.g. 127.0.0.1 `"network" "-1"` will
     return "127.255.255.255").  Values that overflow the network size will
     safely wrap.
+  - `mask`: Applies the given network mask to the address. The network mask is
+  	expressed as a decimal value (e.g. network mask "24" corresponds to
+  	`255.255.255.0`). After applying the network mask, the network mask of the
+  	resulting address will be either the applied network mask or the network mask
+  	of the input address depending on which network is larger
+  	(e.g. 192.168.10.20/24 `"mask" "16"` will return "192.168.0.0/16" but
+  	192.168.10.20/24 `"mask" "28"` will return "192.168.10.16/24").
 
 Example:
 
@@ -219,6 +226,7 @@ Example:
     {{ GetPrivateInterfaces | include "type" "IP" | math "address" "-256" | attr "address" }}
     {{ GetPrivateInterfaces | include "type" "IP" | math "network" "+2" | attr "address" }}
     {{ GetPrivateInterfaces | include "type" "IP" | math "network" "-2" | attr "address" }}
+    {{ GetPrivateInterfaces | include "type" "IP" | math "mask" "24" | attr "address" }}
     {{ GetPrivateInterfaces | include "flags" "forwardable|up" | include "type" "IPv4" | math "network" "+2" | attr "address" }}
 
 


### PR DESCRIPTION
This pull requests adds the `mask` operation to `math`. The mask operation applies an integer network mask to a given input IPv4 or IPv6 address.  

### Documentation

The functionality is described in the added documentation as follows.  

`mask`: Applies the given network mask to the address. The network mask is
  	expressed as a decimal value (e.g. network mask "24" corresponds to
  	`255.255.255.0`). After applying the network mask, the network mask of the
  	resulting address will be either the applied network mask or the network mask
  	of the input address depending on which network is larger
  	(e.g. 192.168.10.20/24 `"mask" "16"` will return "192.168.0.0/16" but
  	192.168.10.20/24 `"mask" "28"` will return "192.168.10.16/24").

### Use Cases

Simple example:

```
{{ GetPrivateInterfaces | include "type" "IP" | math "mask" "24" | attr "address" }}
```

I use this operation in a use case in which I need to calculate an IP address relative to a subnet which is larger than the subnet associated to the input interface. In this case, I could not use the `network` operation which is limited to the subnet mask of the input interface.

```
{{ GetPrivateInterfaces | include "type" "IPv4" | math "mask" "20" | math "network" "+4" | attr "address" }}
```
