### PR TITLE
Allow spaces in interface name

### DIFF
--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -16,7 +16,7 @@ var (
 	// Centralize all regexps and regexp.Copy() where necessary.
 	signRE       *regexp.Regexp = regexp.MustCompile(`^[\s]*[+-]`)
 	whitespaceRE *regexp.Regexp = regexp.MustCompile(`[\s]+`)
-	ifNameRE     *regexp.Regexp = regexp.MustCompile(`^Ethernet adapter ([^\s:]+):`)
+	ifNameRE     *regexp.Regexp = regexp.MustCompile(`^Ethernet adapter ([^:]+):`)
 	ipAddrRE     *regexp.Regexp = regexp.MustCompile(`^   IPv[46] Address\. \. \. \. \. \. \. \. \. \. \. : ([^\s]+)`)
 )
 


### PR DESCRIPTION
Windows can create interfaces with spaces in the name.  This opens up the regex to allow for that.  Fixes #17 