### PR TITLE
Fix formatting issues in tests

### DIFF
--- a/ifaddrs_test.go
+++ b/ifaddrs_test.go
@@ -1326,9 +1326,8 @@ func TestNewIPAddr(t *testing.T) {
 			continue
 		}
 
-		ipStr := ip.String()
-		if ipStr != test.output {
-			t.Errorf("Expected %q to match %q", test.input, test.output, ipStr)
+		if ip.String() != test.output {
+			t.Errorf("Expected %q to match %q", ip.String(), test.output)
 		}
 
 	}
@@ -1964,7 +1963,7 @@ func TestSortIfBy(t *testing.T) {
 
 	for i, test := range tests {
 		if test.name == "" {
-			t.Fatalf("test %i needs a name", i)
+			t.Fatalf("test %d needs a name", i)
 		}
 
 		t.Run(test.name, func(t *testing.T) {

--- a/ifattr_test.go
+++ b/ifattr_test.go
@@ -106,7 +106,7 @@ func testSockAddrAttr(t *testing.T, sai interface{}) {
 				t.Errorf("Unable to fetch attr name %q from %v / %v + %+q", attrTest.name, v, v.Type(), val)
 			}
 		default:
-			t.Fatal("unsupported type %T %v", sai, sai)
+			t.Fatalf("unsupported type %T %v", sai, sai)
 		}
 	}
 }

--- a/ipv4addr_test.go
+++ b/ipv4addr_test.go
@@ -677,15 +677,15 @@ func TestSockAddr_IPv4Addr(t *testing.T) {
 			}
 
 			if v := sockaddr.IsRFC(1918, ipv4); v != test.z21_IsRFC1918 {
-				t.Errorf("[%d] Expected IsRFC(1918, %+q) to be %+q, received %+q", idx, test.z00_input, test.z21_IsRFC1918, v)
+				t.Errorf("[%d] Expected IsRFC(1918, %+q) to be %t, received %t", idx, test.z00_input, test.z21_IsRFC1918, v)
 			}
 
 			if v := sockaddr.IsRFC(6598, ipv4); v != test.z22_IsRFC6598 {
-				t.Errorf("[%d] Expected IsRFC(6598, %+q) to be %+q, received %+q", idx, test.z00_input, test.z22_IsRFC6598, v)
+				t.Errorf("[%d] Expected IsRFC(6598, %+q) to be %t, received %t", idx, test.z00_input, test.z22_IsRFC6598, v)
 			}
 
 			if v := sockaddr.IsRFC(6890, ipv4); v != test.z23_IsRFC6890 {
-				t.Errorf("[%d] Expected IsRFC(6890, %+q) to be %+q, received %+q", idx, test.z00_input, test.z23_IsRFC6890, v)
+				t.Errorf("[%d] Expected IsRFC(6890, %+q) to be %t, received %t", idx, test.z00_input, test.z23_IsRFC6890, v)
 			}
 		})
 	}

--- a/ipv6addr_test.go
+++ b/ipv6addr_test.go
@@ -33,7 +33,7 @@ func newIPv6BigInt(t *testing.T, ipv6Str string) *big.Int {
 	addrStr := strings.Join(strings.Split(ipv6Str, ":"), "")
 	_, ok := addr.SetString(addrStr, 16)
 	if !ok {
-		t.Fatal("Unable to create an IPv6Addr from string %+q", ipv6Str)
+		t.Fatalf("Unable to create an IPv6Addr from string %+q", ipv6Str)
 	}
 
 	return addr

--- a/sockaddrs_test.go
+++ b/sockaddrs_test.go
@@ -93,10 +93,10 @@ func TestSockAddr_SockAddrs_AscAddress(t *testing.T) {
 			sas := convertToSockAddrs(t, test.sortedAddrs)
 			sortedIPv4Addrs, nonIPv4Addrs := sas.FilterByType(sockaddr.TypeIPv4)
 			if l := len(sortedIPv4Addrs); l != test.numIPv4Inputs {
-				t.Fatal("[%d] Missing IPv4Addrs: expected %d, received %d", idx, test.numIPv4Inputs, l)
+				t.Fatalf("[%d] Missing IPv4Addrs: expected %d, received %d", idx, test.numIPv4Inputs, l)
 			}
 			if len(nonIPv4Addrs) != test.numIPv6Inputs+test.numUnixInputs {
-				t.Fatal("[%d] Non-IPv4 Address in input", idx)
+				t.Fatalf("[%d] Non-IPv4 Address in input", idx)
 			}
 
 			// Copy inputAddrs so we can manipulate it. wtb const.


### PR DESCRIPTION
Fix the following formatting issues identified by `make test`:

    ./ifaddrs_test.go:1331: Errorf call needs 2 args but has 3 args
    ./ifaddrs_test.go:1967: Fatalf format %i has unknown verb i
    ./ifattr_test.go:109: Fatal call has possible formatting directive %v
    ./ipv4addr_test.go:680: Errorf format %+q has arg test.z21_IsRFC1918 of wrong type bool
    ./ipv4addr_test.go:684: Errorf format %+q has arg test.z22_IsRFC6598 of wrong type bool
    ./ipv4addr_test.go:688: Errorf format %+q has arg test.z23_IsRFC6890 of wrong type bool
    ./ipv6addr_test.go:36: Fatal call has possible formatting directive %+q
    ./sockaddrs_test.go:96: Fatal call has possible formatting directive %d
    ./sockaddrs_test.go:99: Fatal call has possible formatting directive %d