### PR TITLE
Expanded RegEx to allow wireless adapters on Windows.

### DIFF
--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -16,7 +16,7 @@ var (
 	// Centralize all regexps and regexp.Copy() where necessary.
 	signRE       *regexp.Regexp = regexp.MustCompile(`^[\s]*[+-]`)
 	whitespaceRE *regexp.Regexp = regexp.MustCompile(`[\s]+`)
-	ifNameRE     *regexp.Regexp = regexp.MustCompile(`^Ethernet adapter ([^:]+):`)
+	ifNameRE     *regexp.Regexp = regexp.MustCompile(`^(?:Ethernet|Wireless LAN) adapter ([^:]+):`)
 	ipAddrRE     *regexp.Regexp = regexp.MustCompile(`^   IPv[46] Address\. \. \. \. \. \. \. \. \. \. \. : ([^\s]+)`)
 )
 


### PR DESCRIPTION
The current regex would not see any wireless adapter because it was strictly looking for "Ethernet adapter" this allows a match on "Wireless LAN adapter" as well.

Fixes #20