### PR TITLE
Add a `private` selector to the `include` and `exclude` filters.

### DIFF
--- a/ifaddrs_test.go
+++ b/ifaddrs_test.go
@@ -981,6 +981,39 @@ func TestIncludeExcludeIfs(t *testing.T) {
 			includeParam: `::/127`,
 		},
 		{
+			name: "private",
+			ifAddrs: sockaddr.IfAddrs{
+				sockaddr.IfAddr{
+					SockAddr: sockaddr.MustIPAddr("1.2.3.4"),
+				},
+				sockaddr.IfAddr{
+					SockAddr: sockaddr.MustIPv4Addr("10.2.3.4"),
+				},
+				sockaddr.IfAddr{
+					SockAddr: sockaddr.MustIPAddr("203.0.113.0"),
+				},
+				sockaddr.IfAddr{
+					SockAddr: sockaddr.MustIPAddr("::1"),
+				},
+			},
+			excludeName:  "private",
+			excludeNum:   1,
+			excludeParam: ``,
+			includeName:  "private",
+			includeNum:   3,
+			includeParam: ``,
+		},
+		{
+			name:         "private empty addresses",
+			ifAddrs:      sockaddr.IfAddrs{},
+			excludeName:  "private",
+			excludeNum:   0,
+			excludeParam: ``,
+			includeName:  "private",
+			includeNum:   0,
+			includeParam: ``,
+		},
+		{
 			name: "port",
 			ifAddrs: sockaddr.IfAddrs{
 				sockaddr.IfAddr{


### PR DESCRIPTION
This commit adds support for a `private` selector to the `include` and `exclude`
filters allowing to filter out private IP addresses accordingly leveraging RFC
6890 to identify a private IP addresses. This new functionality would be the
`eval` equivalent of (using include as an example):

````
  $ sockaddr eval -r '{{ GetAllInterfaces | include "rfc" "6890" }}'
````

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>