### PR TITLE
Fix build failures affecting tests

### DIFF
--- a/ipv4addr_test.go
+++ b/ipv4addr_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/go-sockaddr"
+	sockaddr "github.com/hashicorp/go-sockaddr"
 )
 
 func TestSockAddr_IPv4Addr(t *testing.T) {
@@ -656,7 +656,7 @@ func TestSockAddr_IPv4Addr(t *testing.T) {
 				t.Errorf("[%d] Expected %+q's broadcast to be %+q, received %+q", idx, test.z00_input, test.z15_broadcast, b)
 			}
 
-			if p := ipv4.IPPort(); sockaddr.IPPort(p) != test.z16_portInt || sockaddr.IPPort(p) != test.z16_portInt {
+			if p := ipv4.IPPort(); sockaddr.IPPort(p) != test.z16_portInt {
 				t.Errorf("[%d] Expected %+q's port to be %d, received %d", idx, test.z00_input, test.z16_portInt, p)
 			}
 

--- a/ipv6addr_test.go
+++ b/ipv6addr_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/go-sockaddr"
+	sockaddr "github.com/hashicorp/go-sockaddr"
 )
 
 // ipv6HostMask is an unexported big.Int representing a /128 IPv6 address
@@ -427,7 +427,7 @@ func TestSockAddr_IPv6Addr(t *testing.T) {
 				t.Errorf("[%d] Expected %+q's LastUsable() to be %+q, received %+q", idx, test.z00_input, test.z14_lastUsable, l)
 			}
 
-			if p := ipv6.IPPort(); sockaddr.IPPort(p) != test.z16_portInt || sockaddr.IPPort(p) != test.z16_portInt {
+			if p := ipv6.IPPort(); sockaddr.IPPort(p) != test.z16_portInt {
 				t.Errorf("[%d] Expected %+q's port to be %+v, received %+v", idx, test.z00_input, test.z16_portInt, p)
 			}
 


### PR DESCRIPTION
On a newer version of Go that runs `vet` during tests some stray conditionals are flagged as errant. Also when running on Linux one of the tests commented as only working on Darwin fails.