### PR TITLE
remove the test dependency on consul

### DIFF
--- a/sockaddrs_test.go
+++ b/sockaddrs_test.go
@@ -1,16 +1,30 @@
 package sockaddr_test
 
 import (
+	crand "crypto/rand"
 	"fmt"
+	"math"
+	"math/big"
 	"math/rand"
 	"testing"
+	"time"
 
-	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/go-sockaddr"
+	sockaddr "github.com/hashicorp/go-sockaddr"
 )
 
 func init() {
-	lib.SeedMathRand()
+	seedMathRand()
+}
+
+// seedMathRand provides weak, but guaranteed seeding, which is better than
+// running with Go's default seed of 1.
+func seedMathRand() {
+	n, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		rand.Seed(time.Now().UTC().UnixNano())
+		return
+	}
+	rand.Seed(n.Int64())
 }
 
 // NOTE: A number of these code paths are exercised in template/ and


### PR DESCRIPTION
There is a stray test-only dependency on `github.com/hashicorp/consul/lib` in this repository used only to seed the random number generator. When this is a dependency of another project using go modules this creates an unfortunate explosion of additional indirect dependencies for no added benefit.

Inlining this results in 10 fewer indirect dependencies showing up elsewhere. Also it's a little weird when `consul -> memberlist -> go-sockaddr -> consul`