### PR TITLE
Add PowerShell impl. of GetDefaultInterfaceName

### DIFF
--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -16,8 +16,10 @@ var (
 	// Centralize all regexps and regexp.Copy() where necessary.
 	signRE       *regexp.Regexp = regexp.MustCompile(`^[\s]*[+-]`)
 	whitespaceRE *regexp.Regexp = regexp.MustCompile(`[\s]+`)
-	ifNameRE     *regexp.Regexp = regexp.MustCompile(`^(?:Ethernet|Wireless LAN) adapter ([^:]+):`)
-	ipAddrRE     *regexp.Regexp = regexp.MustCompile(`^   IPv[46] Address\. \. \. \. \. \. \. \. \. \. \. : ([^\s]+)`)
+	// These regular expressions enable the deprecated parseDefaultIfNameWindows
+	// and should be removed when those functions are.
+	ifNameRE *regexp.Regexp = regexp.MustCompile(`^(?:Ethernet|Wireless LAN) adapter ([^:]+):`)
+	ipAddrRE *regexp.Regexp = regexp.MustCompile(`^   IPv[46] Address\. \. \. \. \. \. \. \. \. \. \. : ([^\s]+)`)
 )
 
 // IfAddrs is a slice of IfAddr
@@ -1214,14 +1216,13 @@ func parseDefaultIfNameFromIPCmd(routeOut string) (string, error) {
 // Android.
 func parseDefaultIfNameFromIPCmdAndroid(routeOut string) (string, error) {
 	parsedLines := parseIfNameFromIPCmd(routeOut)
-	if (len(parsedLines) > 0) {
+	if len(parsedLines) > 0 {
 		ifName := strings.TrimSpace(parsedLines[0][4])
 		return ifName, nil
 	}
 
 	return "", errors.New("No default interface found")
 }
-
 
 // parseIfNameFromIPCmd parses interfaces from ip(8) for
 // Linux.
@@ -1241,6 +1242,10 @@ func parseIfNameFromIPCmd(routeOut string) [][]string {
 
 // parseDefaultIfNameWindows parses the default interface from `netstat -rn` and
 // `ipconfig` on Windows.
+//
+// This has been deprecated in favor of a Powershell-based solution because of
+// issues with localized Windows versions, but is currently retained for backward
+// compatibility
 func parseDefaultIfNameWindows(routeOut, ipconfigOut string) (string, error) {
 	defaultIPAddr, err := parseDefaultIPAddrWindowsRoute(routeOut)
 	if err != nil {
@@ -1262,6 +1267,10 @@ func parseDefaultIfNameWindows(routeOut, ipconfigOut string) (string, error) {
 // IPv6 connected host, submit an issue on github.com/hashicorp/go-sockaddr with
 // the output from `netstat -rn`, `ipconfig`, and version of Windows to see IPv6
 // support added.
+//
+// This has been deprecated in favor of a Powershell-based solution because of
+// issues with localized Windows versions, but is currently retained for backward
+// compatibility.
 func parseDefaultIPAddrWindowsRoute(routeOut string) (string, error) {
 	lines := strings.Split(routeOut, "\n")
 	re := whitespaceRE.Copy()
@@ -1282,6 +1291,10 @@ func parseDefaultIPAddrWindowsRoute(routeOut string) (string, error) {
 
 // parseDefaultIfNameWindowsIPConfig parses the output of `ipconfig` to find the
 // interface name forwarding traffic to the default gateway.
+//
+// This has been deprecated in favor of a Powershell-based solution because of
+// issues with localized Windows versions, but is currently retained for backward
+// compatibility
 func parseDefaultIfNameWindowsIPConfig(defaultIPAddr, routeOut string) (string, error) {
 	lines := strings.Split(routeOut, "\n")
 	ifNameRe := ifNameRE.Copy()

--- a/route_info_test_windows.go
+++ b/route_info_test_windows.go
@@ -1,0 +1,25 @@
+package sockaddr
+
+import "testing"
+
+func Test_parseWindowsDefaultIfName_new_vs_old(t *testing.T) {
+	if !hasPowershell() {
+		t.Skip("this test requires powershell.")
+		return
+	}
+	ri, err := NewRouteInfo()
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+	psVer, err1 := ri.GetDefaultInterfaceName()
+	legacyVer, err2 := ri.GetDefaultInterfaceNameLegacy()
+	if err1 != nil {
+		t.Errorf("err != nil for GetDefaultInterfaceName - %v", err1)
+	}
+	if err2 != nil {
+		t.Errorf("err != nil for GetDefaultInterfaceNameLegacy - %v", err2)
+	}
+	if psVer != legacyVer {
+		t.Errorf("got %s; want %s", psVer, legacyVer)
+	}
+}

--- a/route_info_windows.go
+++ b/route_info_windows.go
@@ -1,8 +1,14 @@
 package sockaddr
 
-import "os/exec"
+import (
+	"os/exec"
+	"strings"
+)
 
 var cmds map[string][]string = map[string][]string{
+	"defaultInterface": {"powershell", "Get-NetRoute -DestinationPrefix '0.0.0.0/0' | select -ExpandProperty InterfaceAlias"},
+	// These commands enable GetDefaultInterfaceNameLegacy and should be removed
+	// when it is.
 	"netstat":  {"netstat", "-rn"},
 	"ipconfig": {"ipconfig"},
 }
@@ -22,6 +28,21 @@ func NewRouteInfo() (routeInfo, error) {
 // GetDefaultInterfaceName returns the interface name attached to the default
 // route on the default interface.
 func (ri routeInfo) GetDefaultInterfaceName() (string, error) {
+	if hasPowershell() {
+		ifNameOut, err := exec.Command(cmds["defaultInterface"][0], cmds["defaultInterface"][1:]...).Output()
+		if err != nil {
+			return "", err
+		}
+		ifName := strings.TrimSpace(string(ifNameOut[:]))
+		return ifName, nil
+	} else {
+		return ri.GetDefaultInterfaceNameLegacy()
+	}
+}
+
+// GetDefaultInterfaceNameLegacy provides legacy behavior for GetDefaultInterfaceName
+// on Windows machines without powershell.
+func (ri routeInfo) GetDefaultInterfaceNameLegacy() (string, error) {
 	ifNameOut, err := exec.Command(cmds["netstat"][0], cmds["netstat"][1:]...).Output()
 	if err != nil {
 		return "", err
@@ -38,4 +59,9 @@ func (ri routeInfo) GetDefaultInterfaceName() (string, error) {
 	}
 
 	return ifName, nil
+}
+
+func hasPowershell() bool {
+	_, err := exec.LookPath("powershell")
+	return (err != nil)
 }

--- a/route_info_windows.go
+++ b/route_info_windows.go
@@ -28,16 +28,18 @@ func NewRouteInfo() (routeInfo, error) {
 // GetDefaultInterfaceName returns the interface name attached to the default
 // route on the default interface.
 func (ri routeInfo) GetDefaultInterfaceName() (string, error) {
-	if hasPowershell() {
-		ifNameOut, err := exec.Command(cmds["defaultInterface"][0], cmds["defaultInterface"][1:]...).Output()
-		if err != nil {
-			return "", err
-		}
-		ifName := strings.TrimSpace(string(ifNameOut[:]))
-		return ifName, nil
-	} else {
+	if !hasPowershell() {
+		// No powershell, fallback to legacy method
 		return ri.GetDefaultInterfaceNameLegacy()
 	}
+
+	ifNameOut, err := exec.Command(cmds["defaultInterface"][0], cmds["defaultInterface"][1:]...).Output()
+	if err != nil {
+		return "", err
+	}
+
+	ifName := strings.TrimSpace(string(ifNameOut[:]))
+	return ifName, nil
 }
 
 // GetDefaultInterfaceNameLegacy provides legacy behavior for GetDefaultInterfaceName


### PR DESCRIPTION
Allows localized versions of Windows to work correctly since it does not rely on string parsing. New behavior is dependent on `powershell` being in the path. Will fallback to old behavior if PS is not available.