### PR TITLE
Feature/get interface ip nonforwardable network adapters handling

### DIFF
--- a/ifaddr.go
+++ b/ifaddr.go
@@ -141,9 +141,9 @@ func GetPublicIPs() (string, error) {
 	return strings.Join(ips, " "), nil
 }
 
-// GetInterfaceIP returns a string with a single IP address sorted by the size
-// of the network (i.e. IP addresses with a smaller netmask, larger network
-// size, are sorted first).  This function is the `eval` equivalent of:
+// GetInterfaceIP returns a string with a single forwardable IP address sorted
+// by the size of the network (i.e. IP addresses with a smaller netmask, larger
+// network size, are sorted first).  This function is the `eval` equivalent of:
 //
 // ```
 // $ sockaddr eval -r '{{GetAllInterfaces | include "name" <<ARG>> | sort "type,size" | include "flag" "forwardable" | attr "address" }}'

--- a/ifaddr_private_test.go
+++ b/ifaddr_private_test.go
@@ -1,0 +1,100 @@
+package sockaddr
+
+import (
+	"net"
+	"testing"
+)
+
+//Test_getInterfaceIPByFlags is here to facilitate testing of the private function getInterfaceIPByFlags
+func Test_getInterfaceIPByFlags(t *testing.T) {
+
+	ifAddrs := IfAddrs{
+		{
+			SockAddr: MustIPv4Addr("127.0.0.0/8"),
+			Interface: net.Interface{
+				Index: 1,
+				MTU:   65536,
+				Name:  "lo",
+				Flags: net.FlagUp | net.FlagLoopback,
+			},
+		},
+		{
+			SockAddr: MustIPv4Addr("172.16.0.0/12"),
+			Interface: net.Interface{
+				Index: 2,
+				MTU:   1500,
+				Name:  "eth0",
+				Flags: net.FlagUp,
+			},
+		},
+		{
+			SockAddr: MustIPv4Addr("169.254.0.0/16"),
+			Interface: net.Interface{
+				Index: 3,
+				MTU:   1500,
+				Name:  "dummy",
+				Flags: net.FlagBroadcast,
+			},
+		},
+	}
+
+	type args struct {
+		namedIfRE string
+		flags     []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "loopback: no flags provided => 127.0.0.0",
+			args:    args{namedIfRE: "lo", flags: []string{}},
+			want:    "127.0.0.0",
+			wantErr: false,
+		},
+		{
+			name:    "loopback: `forwardable` flag provided => empty string",
+			args:    args{namedIfRE: "lo", flags: []string{"forwardable"}},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name:    "private (RFC1918): no flags provided => 172.16.0.0",
+			args:    args{namedIfRE: "eth0", flags: []string{}},
+			want:    "172.16.0.0",
+			wantErr: false,
+		},
+		{
+			name:    "private (RFC1918): `broadcast` flag provided but iface is not broadcast => empty string",
+			args:    args{namedIfRE: "eth0", flags: []string{"broadcast"}},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name:    "dummy (RFC3927): no flags provided => 169.254.0.0",
+			args:    args{namedIfRE: "dummy", flags: []string{}},
+			want:    "169.254.0.0",
+			wantErr: false,
+		},
+		{
+			name:    "dummy (RFC3927): `forwardable` flag provided => empty string",
+			args:    args{namedIfRE: "dummy", flags: []string{"forwardable"}},
+			want:    "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getInterfaceIPByFlags(tt.args.namedIfRE, tt.args.flags, ifAddrs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getInterfaceIPByFlags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getInterfaceIPByFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ifaddr_test.go
+++ b/ifaddr_test.go
@@ -128,6 +128,17 @@ func TestGetInterfaceIP(t *testing.T) {
 	}
 }
 
+func TestGetInterfaceIPRegardlessOfInterfaceFlags(t *testing.T) {
+	ip, err := sockaddr.GetInterfaceIPRegardlessOfInterfaceFlags(`^.*[\d]$`)
+	if err != nil {
+		t.Fatalf("regexp failed: %v", err)
+	}
+
+	if ip == "" {
+		t.Skip("it's hard to test this reliably")
+	}
+}
+
 func TestIfAddrAttr(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -1214,14 +1214,13 @@ func parseDefaultIfNameFromIPCmd(routeOut string) (string, error) {
 // Android.
 func parseDefaultIfNameFromIPCmdAndroid(routeOut string) (string, error) {
 	parsedLines := parseIfNameFromIPCmd(routeOut)
-	if (len(parsedLines) > 0) {
+	if len(parsedLines) > 0 {
 		ifName := strings.TrimSpace(parsedLines[0][4])
 		return ifName, nil
 	}
 
 	return "", errors.New("No default interface found")
 }
-
 
 // parseIfNameFromIPCmd parses interfaces from ip(8) for
 // Linux.

--- a/template/template.go
+++ b/template/template.go
@@ -95,6 +95,9 @@ func init() {
 		// the largest network size.
 		"GetInterfaceIP": sockaddr.GetInterfaceIP,
 
+		// Returns the first IP address of the named interfaces, regardless of any interface flag
+		"GetInterfaceIPRegardlessOfInterfaceFlags": sockaddr.GetInterfaceIPRegardlessOfInterfaceFlags,
+
 		// Return all IP addresses on the named interface, sorted by the largest
 		// network size.
 		"GetInterfaceIPs": sockaddr.GetInterfaceIPs,


### PR DESCRIPTION
Hi there, this PR addresses what was discovered in #31 quite a while ago and that I found by looking at the Consul issue https://github.com/hashicorp/consul/issues/5371.

Basically it simply clarifies `GetInterfaceIP`'s behaviour and also adds `GetInterfaceIPRegardlessOfInterfaceFlags` (not sure about the naming of this one since we are only preventing the exclusion of `forwardable=false` interfaces).



