### PR TITLE
make unix socket implement SockAddr interface

### DIFF
--- a/unixsock.go
+++ b/unixsock.go
@@ -51,6 +51,9 @@ func (us UnixSock) CmpAddress(sa SockAddr) int {
 	return strings.Compare(us.Path(), usb.Path())
 }
 
+// CmpRFC doesn't make sense for a Unix socket, so just return defer decision
+func (us UnixSock) CmpRFC(rfcNum uint, sa SockAddr) int { return sortDeferDecision }
+
 // DialPacketArgs returns the arguments required to be passed to net.DialUnix()
 // with the `unixgram` network type.
 func (us UnixSock) DialPacketArgs() (network, dialArgs string) {


### PR DESCRIPTION
`UnixSock` claims to implement the `SockAddr` interface, but does not have the required `Contains` method. As a result, `(UnixSock).SockAddr` was nil, which was causing panics when a `UnixSock` was used as a `SockAddr`. 


This behavior was brought to life by this issue: https://github.com/hashicorp/vault/issues/14350