### PR TITLE
Fix SortIPAddrsByNetworkSize

### DIFF
--- a/ipaddrs.go
+++ b/ipaddrs.go
@@ -67,9 +67,13 @@ func (s SortIPAddrsByNetworkSize) Less(i, j int) bool {
 	// that have a port (e.g. a host with a /32 and port number is more
 	// specific and should sort first over a host with a /32 but no port
 	// set).
-	if s.IPAddrs[i].IPPort() == 0 || s.IPAddrs[j].IPPort() == 0 {
+	if s.IPAddrs[i].IPPort() == 0 && s.IPAddrs[j].IPPort() != 0 {
 		return false
 	}
+	if s.IPAddrs[i].IPPort() != 0 && s.IPAddrs[j].IPPort() == 0 {
+		return true
+	}
+
 	return s.IPAddrs[i].IPPort() < s.IPAddrs[j].IPPort()
 }
 


### PR DESCRIPTION
`SortIPAddrsByNetworkSize()` fails to properly sort hosts where the definitive criteria is the host having a port. For example:

```
128.95.120.2/32
128.95.120.2:8600
```

Should be:

```
128.95.120.2:8600
128.95.120.2/32
```

Caused by a logic error and fixed in this PR.

Funny though, this exact test case is part of the tests. The `Sort()` algorithm was changed to `pdqsort` in https://github.com/golang/go/commit/72e77a7f41bbf45d466119444307fd3ae996e257 and was originally released in Go 1.19. Tests pass in Go 1.18 but fail in Go 1.19. Just so it happens, the order of operations in previous `Sort()` implementation happens to mask this bug with the given test array.

Fixes #45.