### PR TITLE
fix hasPowershell

### DIFF
--- a/route_info_windows.go
+++ b/route_info_windows.go
@@ -61,5 +61,5 @@ func (ri routeInfo) GetDefaultInterfaceNameLegacy() (string, error) {
 
 func hasPowershell() bool {
 	_, err := exec.LookPath("powershell")
-	return (err != nil)
+	return (err == nil)
 }


### PR DESCRIPTION
See [issue-56](https://github.com/hashicorp/go-sockaddr/issues/56)

hasPowershell was behaving as hasNotPowershell by returning err!=nil