### PR TITLE
Update readme to use `go install` as `go get -u` is no longer valid for installing modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the
 run:
 
 ```text
-$ go get -u github.com/hashicorp/go-sockaddr/cmd/sockaddr
+$ go install github.com/hashicorp/go-sockaddr/cmd/sockaddr@latest
 ```
 
 If you're familiar with UNIX's `sockaddr` struct's, the following diagram

--- a/cmd/sockaddr/README.md
+++ b/cmd/sockaddr/README.md
@@ -4,7 +4,7 @@
 from the command line.
 
 ```text
-$ go get -u github.com/hashicorp/go-sockaddr/cmd/sockaddr
+$ go install github.com/hashicorp/go-sockaddr/cmd/sockaddr@latest
 ```
 
 ```text


### PR DESCRIPTION
Small docs update