### PR TITLE
AIX support and build tag fixes

### DIFF
--- a/route_info_aix.go
+++ b/route_info_aix.go
@@ -1,0 +1,37 @@
+package sockaddr
+
+import (
+	"errors"
+	"os/exec"
+)
+
+var cmds map[string][]string = map[string][]string{
+	"route": {"/usr/sbin/route", "-n", "get", "default"},
+}
+
+type routeInfo struct {
+	cmds map[string][]string
+}
+
+// NewRouteInfo returns a BSD-specific implementation of the RouteInfo
+// interface.
+func NewRouteInfo() (routeInfo, error) {
+	return routeInfo{
+		cmds: cmds,
+	}, nil
+}
+
+// GetDefaultInterfaceName returns the interface name attached to the default
+// route on the default interface.
+func (ri routeInfo) GetDefaultInterfaceName() (string, error) {
+	out, err := exec.Command(cmds["route"][0], cmds["route"][1:]...).Output()
+	if err != nil {
+		return "", err
+	}
+
+	var ifName string
+	if ifName, err = parseDefaultIfNameFromRoute(string(out)); err != nil {
+		return "", errors.New("No default interface found")
+	}
+	return ifName, nil
+}

--- a/route_info_aix.go
+++ b/route_info_aix.go
@@ -1,3 +1,5 @@
+//go:build aix
+
 package sockaddr
 
 import (
@@ -7,10 +9,6 @@ import (
 
 var cmds map[string][]string = map[string][]string{
 	"route": {"/usr/sbin/route", "-n", "get", "default"},
-}
-
-type routeInfo struct {
-	cmds map[string][]string
 }
 
 // NewRouteInfo returns a BSD-specific implementation of the RouteInfo

--- a/route_info_android.go
+++ b/route_info_android.go
@@ -1,13 +1,11 @@
+//go:build android
+
 package sockaddr
 
 import (
 	"errors"
 	"os/exec"
 )
-
-type routeInfo struct {
-	cmds map[string][]string
-}
 
 // NewRouteInfo returns a Android-specific implementation of the RouteInfo
 // interface.

--- a/route_info_default.go
+++ b/route_info_default.go
@@ -1,5 +1,5 @@
-//go:build android || nacl || plan9 || js
-// +build android nacl plan9 js
+//go:build nacl || plan9 || js
+// +build nacl plan9 js
 
 package sockaddr
 

--- a/route_info_solaris.go
+++ b/route_info_solaris.go
@@ -1,3 +1,5 @@
+//go:build solaris
+
 package sockaddr
 
 import (


### PR DESCRIPTION
This PR is to bring #37 up to speed with master. Build tags were needed for the Solaris route info code so it wouldn't be built for GOOS=aix.

Additionally, I ran a `go build` against each GOOS target and found that Android is broken in master. I made the necessary tweaks to get the build to succeed, but I'm unable to test it. It's in this PR because it was adjacent to the work I was doing, but I can drop it or submit a second PR for it if desired.

Thanks,
John