### PR TITLE
ci: Add copywrite workflow and modernize lint config. 

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,9 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2016
+}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,6 +3,8 @@ name: Build and Test Workflow
 on:
     pull_request:
         branches: [ "master" ]
+    push:
+        branches: [ "master" ]
 
 jobs:
     build:
@@ -22,7 +24,7 @@ jobs:
               with:
                 go-version: ${{ matrix.version }}
             - name: Test Go
-              run: go test -v -coverprofile=coverage.out ./...
+              run: go test -v -race -coverprofile=coverage.out ./...
             - name: Upload coverage report
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with: 

--- a/.github/workflows/copywrite.yaml
+++ b/.github/workflows/copywrite.yaml
@@ -1,0 +1,24 @@
+name: Check Copywrite Headers
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  copywrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
+        name: Setup Copywrite
+        with:
+          version: v0.25.3
+          archive-checksum: e43f4b72fff3f219c5a5f883438d63edd5b68f5bea90a5d18abb3001c8c3aedc
+      - name: Check Header Compliance
+        run: make copywriteheaders
+permissions:
+  contents: read

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+# Copyright IBM Corp. 2016, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+version: "2"
+
+linters:
+  enable:
+    - gocyclo
+    - govet
+    - ineffassign
+    - misspell
+    - modernize
+    - staticcheck
+  settings:
+    gocyclo:
+      min-complexity: 60

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,21 +22,20 @@ $(GOCOVERHTML): $(GOCOVER_FILE)
 coverage_report:: $(GOCOVER_FILE)
 	go tool cover -html=$(GOCOVER_FILE)
 
-audit_tools::
-	@go get -u github.com/golang/lint/golint && echo "Installed golint:"
-	@go get -u github.com/fzipp/gocyclo && echo "Installed gocyclo:"
-	@go get -u github.com/remyoudompheng/go-misc/deadcode && echo "Installed deadcode:"
-	@go get -u github.com/client9/misspell/cmd/misspell && echo "Installed misspell:"
-	@go get -u github.com/gordonklaus/ineffassign && echo "Installed ineffassign:"
+deps::
+	@go install github.com/hashicorp/copywrite@b3e6599f43beff698f471c6f46888045453fa030 # v0.25.3
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@c0d3ddc9cf3faa61a4e378e879ece580256d76e5 # v2.12.2
 
-audit::
-	deadcode
-	go tool vet -all *.go
-	go tool vet -shadow=true *.go
-	golint *.go
-	ineffassign .
-	gocyclo -over 65 *.go
-	misspell *.go
+.PHONY: copywriteheaders
+copywriteheaders:
+	@echo "==> Running copywrite headers plan..."
+	@copywrite headers --plan
+	@echo "==> Done"
+
+lint::
+	@echo "==> Running linters..."
+	@golangci-lint run ./...
+	@echo "==> Done"
 
 clean::
 	rm -f $(GOCOVER_FILE) $(GOCOVERHTML)

--- a/cmd/sockaddr/command/dump.go
+++ b/cmd/sockaddr/command/dump.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command
@@ -170,7 +170,7 @@ func (c *DumpCommand) dumpSockAddr(sa sockaddr.SockAddr) {
 
 	// outFmt is a small helper function to reduce the tedium below.  outFmt
 	// returns a new slice and expects the value to already be a string.
-	outFmt := func(o []string, k sockaddr.AttrName, v interface{}) []string {
+	outFmt := func(o []string, k sockaddr.AttrName, v any) []string {
 		if !allowedAttr(k) {
 			return o
 		}

--- a/cmd/sockaddr/command/tech_support.go
+++ b/cmd/sockaddr/command/tech_support.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command
@@ -80,7 +80,7 @@ func (c *TechSupportCommand) Run(args []string) int {
 	ri.VisitCommands(func(name string, cmd []string) {
 		out, err := exec.Command(cmd[0], cmd[1:]...).Output()
 		if err != nil {
-			out = []byte(fmt.Sprintf("ERROR: command %q failed: %v", name, err))
+			out = fmt.Appendf(out, "ERROR: command %q failed: %v", name, err)
 		}
 
 		output[name] = cmdResult{
@@ -170,7 +170,7 @@ func (c *TechSupportCommand) parseOpts(args []string) ([]string, error) {
 	return c.flags.Args(), nil
 }
 
-func (c *TechSupportCommand) rowWriterOutputFactory() func(valueVerb, key string, val interface{}) {
+func (c *TechSupportCommand) rowWriterOutputFactory() func(valueVerb, key string, val any) {
 	type _Fmt string
 	type _Verb string
 	var lineNoFmt string
@@ -200,7 +200,7 @@ func (c *TechSupportCommand) rowWriterOutputFactory() func(valueVerb, key string
 	}
 
 	var count int
-	return func(valueVerb, key string, val interface{}) {
+	return func(valueVerb, key string, val any) {
 		count++
 
 		keyFmt, ok := fmtMap[keyVerb]

--- a/ifaddr_test.go
+++ b/ifaddr_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sockaddr_test
@@ -49,7 +49,7 @@ func havePublicIP() bool {
 }
 
 func TestGetPrivateIP(t *testing.T) {
-	reportOnPrivate := func(args ...interface{}) {
+	reportOnPrivate := func(args ...any) {
 		if havePrivateIP() {
 			t.Fatalf(args[0].(string), args[1:]...)
 		} else {
@@ -67,7 +67,7 @@ func TestGetPrivateIP(t *testing.T) {
 }
 
 func TestGetPrivateIPs(t *testing.T) {
-	reportOnPrivate := func(args ...interface{}) {
+	reportOnPrivate := func(args ...any) {
 		if havePrivateIP() {
 			t.Fatalf(args[0].(string), args[1:]...)
 		} else {
@@ -85,7 +85,7 @@ func TestGetPrivateIPs(t *testing.T) {
 }
 
 func TestGetPublicIP(t *testing.T) {
-	reportOnPublic := func(args ...interface{}) {
+	reportOnPublic := func(args ...any) {
 		if havePublicIP() {
 			t.Fatalf(args[0].(string), args[1:]...)
 		} else {
@@ -103,7 +103,7 @@ func TestGetPublicIP(t *testing.T) {
 }
 
 func TestGetPublicIPs(t *testing.T) {
-	reportOnPublic := func(args ...interface{}) {
+	reportOnPublic := func(args ...any) {
 		if havePublicIP() {
 			t.Fatalf(args[0].(string), args[1:]...)
 		} else {

--- a/ifaddrs.go
+++ b/ifaddrs.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sockaddr
@@ -509,7 +509,7 @@ func IfByRFC(selectorParam string, ifAddrs IfAddrs) (matched, remainder IfAddrs,
 // up in both the included and excluded list.
 func IfByRFCs(selectorParam string, ifAddrs IfAddrs) (matched, remainder IfAddrs, err error) {
 	var includedIfs, excludedIfs IfAddrs
-	for _, rfcStr := range strings.Split(selectorParam, "|") {
+	for rfcStr := range strings.SplitSeq(selectorParam, "|") {
 		includedRFCIfs, excludedRFCIfs, err := IfByRFC(rfcStr, ifAddrs)
 		if err != nil {
 			return IfAddrs{}, IfAddrs{}, fmt.Errorf("unable to lookup RFC number %q: %v", rfcStr, err)
@@ -624,7 +624,7 @@ func IfByFlag(inputFlags string, ifAddrs IfAddrs) (matched, remainder IfAddrs, e
 		wantUnspecified bool
 	var ifFlags net.Flags
 	var checkFlags, checkAttrs bool
-	for _, flagName := range strings.Split(strings.ToLower(inputFlags), "|") {
+	for flagName := range strings.SplitSeq(strings.ToLower(inputFlags), "|") {
 		switch flagName {
 		case "broadcast":
 			checkFlags = true
@@ -712,7 +712,7 @@ func IfByFlag(inputFlags string, ifAddrs IfAddrs) (matched, remainder IfAddrs, e
 // network passed in by selector.
 func IfByNetwork(selectorParam string, inputIfAddrs IfAddrs) (IfAddrs, IfAddrs, error) {
 	var includedIfs, excludedIfs IfAddrs
-	for _, netStr := range strings.Split(selectorParam, "|") {
+	for netStr := range strings.SplitSeq(selectorParam, "|") {
 		netAddr, err := NewIPAddr(netStr)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to create an IP address from %+q: %v", netStr, err)
@@ -897,11 +897,7 @@ func IfAddrMath(operation, value string, inputIfAddr IfAddr) (IfAddr, error) {
 			maskedIpv4 := ipv4.NetIP().Mask(ipv4Mask)
 			maskedIpv4Uint32 := binary.BigEndian.Uint32(maskedIpv4)
 
-			maskedIpv4MaskUint32 := uint32(ipv4.Mask)
-
-			if ipv4MaskUint32 < maskedIpv4MaskUint32 {
-				maskedIpv4MaskUint32 = ipv4MaskUint32
-			}
+			maskedIpv4MaskUint32 := min(ipv4MaskUint32, uint32(ipv4.Mask))
 
 			return IfAddr{
 				SockAddr: IPv4Addr{
@@ -1184,8 +1180,8 @@ func (ifAddr IfAddr) String() string {
 // parseDefaultIfNameFromRoute parses standard route(8)'s output for the *BSDs
 // and Solaris.
 func parseDefaultIfNameFromRoute(routeOut string) (string, error) {
-	lines := strings.Split(routeOut, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(routeOut, "\n")
+	for line := range lines {
 		kvs := strings.SplitN(line, ":", 2)
 		if len(kvs) != 2 {
 			continue
@@ -1263,8 +1259,8 @@ func parseDefaultIfNameWindows(routeOut, ipconfigOut string) (string, error) {
 // issues with localized Windows versions, but is currently retained for backward
 // compatibility.
 func parseDefaultIPAddrWindowsRoute(routeOut string) (string, error) {
-	lines := strings.Split(routeOut, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(routeOut, "\n")
+	for line := range lines {
 		kvs := whitespaceRE.Split(strings.TrimSpace(line), -1)
 		if len(kvs) < 3 {
 			continue

--- a/ifaddrs_test.go
+++ b/ifaddrs_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sockaddr_test
@@ -683,7 +683,7 @@ func TestGetIfAddrs(t *testing.T) {
 // TestGetDefaultIfName tests to make sure a default interface name is always
 // returned from getDefaultIfName().
 func TestGetDefaultInterface(t *testing.T) {
-	reportOnDefault := func(args ...interface{}) {
+	reportOnDefault := func(args ...any) {
 		if havePublicIP() || havePrivateIP() {
 			t.Fatalf(args[0].(string), args[1:]...)
 		} else {
@@ -793,7 +793,7 @@ func TestGetAllInterfaces(t *testing.T) {
 }
 
 func TestGetDefaultInterfaces(t *testing.T) {
-	reportOnDefault := func(args ...interface{}) {
+	reportOnDefault := func(args ...any) {
 		if havePublicIP() || havePrivateIP() {
 			t.Fatalf(args[0].(string), args[1:]...)
 		} else {
@@ -812,7 +812,7 @@ func TestGetDefaultInterfaces(t *testing.T) {
 }
 
 func TestGetPrivateInterfaces(t *testing.T) {
-	reportOnPrivate := func(args ...interface{}) {
+	reportOnPrivate := func(args ...any) {
 		if havePrivateIP() {
 			t.Fatalf(args[0].(string), args[1:]...)
 		} else {
@@ -835,7 +835,7 @@ func TestGetPrivateInterfaces(t *testing.T) {
 }
 
 func TestGetPublicInterfaces(t *testing.T) {
-	reportOnPublic := func(args ...interface{}) {
+	reportOnPublic := func(args ...any) {
 		if havePublicIP() {
 			t.Fatalf(args[0].(string), args[1:]...)
 		} else {
@@ -1438,7 +1438,7 @@ func TestUniqueIfAddrsBy(t *testing.T) {
 				t.Fatalf("%s: failed uniquify by attribute %s", test.name, test.selector)
 			}
 
-			for i := 0; i < len(uniqueAddrs); i++ {
+			for i := range uniqueAddrs {
 				got := uniqueAddrs[i].String()
 				if got != test.expected[i] {
 					t.Fatalf("%s: expected %q got %q", test.name, test.expected[i], got)
@@ -1994,7 +1994,7 @@ func TestSortIfBy(t *testing.T) {
 				t.Fatalf("wrong len")
 			}
 
-			for i := 0; i < len(sorted); i++ {
+			for i := range sorted {
 				if !reflect.DeepEqual(sorted[i], test.out[i]) {
 					t.Errorf("wrong sort order: %d %v %v", i, sorted[i], test.out[i])
 				}

--- a/ifattr_test.go
+++ b/ifattr_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sockaddr_test
@@ -41,7 +41,7 @@ func TestIfAttr_unix(t *testing.T) {
 	}
 }
 
-func testSockAddrAttr(t *testing.T, sai interface{}) {
+func testSockAddrAttr(t *testing.T, sai any) {
 	attrNamesPerType := []struct {
 		name     sockaddr.AttrName
 		ipv4Pass bool

--- a/ipv6addr.go
+++ b/ipv6addr.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sockaddr
@@ -566,7 +566,7 @@ func bigIntToNetIPv6(bi *big.Int) *net.IP {
 	x := make(net.IP, IPv6len)
 	ipv6Bytes := bi.Bytes()
 
-	// It's possibe for ipv6Bytes to be less than IPv6len bytes in size.  If
+	// It's possible for ipv6Bytes to be less than IPv6len bytes in size.  If
 	// they are different sizes we to pad the size of response.
 	if len(ipv6Bytes) < IPv6len {
 		buf := new(bytes.Buffer)

--- a/template/template.go
+++ b/template/template.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package template
@@ -105,7 +105,7 @@ func init() {
 
 // Attr returns the attribute from the ifAddrRaw argument.  If the argument is
 // an IfAddrs, only the first element will be evaluated for resolution.
-func Attr(selectorName string, ifAddrsRaw interface{}) (string, error) {
+func Attr(selectorName string, ifAddrsRaw any) (string, error) {
 	switch v := ifAddrsRaw.(type) {
 	case sockaddr.IfAddr:
 		return sockaddr.IfAttr(selectorName, v)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package template_test
@@ -380,7 +380,6 @@ func TestSockAddr_Parse(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		test := test // capture range variable
 		if test.name == "" {
 			t.Fatalf("test number %d has an empty test name", i)
 		}


### PR DESCRIPTION
This changes adds a copywrite workflow to meet compliance requirements along with a makefile target.

The code lint has been moved over to golangci-lint and enabled the linters that were manually installed where possible. A makefile target has also been added for easier local running.

The test workflow now also runs tests with the race flag, to ensure these are surfaced.

Jira: https://hashicorp.atlassian.net/browse/NMD-1553